### PR TITLE
Delete setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[bdist_wheel]
-universal = 1
-


### PR DESCRIPTION
Just noticed this has the same issue as in https://github.com/nicoddemus/pytest-faulthandler/pull/2

```
$ python --version       
Python 3.4.3
$ pip install pytest-mock
Collecting pytest-mock
  Downloading pytest_mock-0.4.1-py2.py3-none-any.whl
Collecting mock (from pytest-mock)
  Downloading mock-1.0.1.tar.gz (818kB)
...
```