### PR TITLE
simplify and fix the mock fixture

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -78,13 +78,12 @@ def mocker():
     result.stopall()
 
 
-@pytest.yield_fixture
-def mock():
+@pytest.fixture
+def mock(mocker):
     """
     Same as "mocker", but kept only for backward compatibility.
     """
     import warnings
     warnings.warn('"mock" fixture has been deprecated, use "mocker" instead',
                   DeprecationWarning)
-    for m in mocker():
-        yield m
+    return mocker


### PR DESCRIPTION
directly use the mocker fixture instead of secretly invoking it outside of pytest resulting in 2 objects in case of mixed usage