### PR TITLE
Add Mock/MagicMock to MockFixture class for instantiation

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -15,6 +15,9 @@ class MockFixture(object):
     ensuring that they are uninstalled at the end of each test.
     """
 
+    Mock = mock_module.Mock
+    MagicMock = mock_module.MagicMock
+
     def __init__(self):
         self._patches = []  # list of mock._patch objects
         self.patch = self._Patcher(self._patches)

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -5,6 +5,7 @@ import pytest
 
 pytest_plugins = 'pytester'
 
+
 class UnixFS(object):
     """
     Wrapper to os functions to simulate a Unix file system, used for testing
@@ -121,3 +122,17 @@ def test_deprecated_mock(mock, tmpdir):
     assert os.listdir(str(tmpdir)) == ['mocked']
     mock.stopall()
     assert os.listdir(str(tmpdir)) == []
+
+
+def test_mocker_has_magic_mock_class_as_attribute_for_instantiation():
+    from pytest_mock import mock_module, MockFixture
+
+    mocker = MockFixture()
+    assert isinstance(mocker.MagicMock(), mock_module.MagicMock)
+
+
+def test_mocker_has_mock_class_as_attribute_for_instantiation():
+    from pytest_mock import mock_module, MockFixture
+
+    mocker = MockFixture()
+    assert isinstance(mocker.Mock(), mock_module.Mock)


### PR DESCRIPTION
Instantiate Mocks and MagicMocks using mocker.

Example use case:

```python
def test_my_feature_with_pytest_mock(mocker):
    ret = [mocker.Mock(return_value=True), mocker.Mock(return_value=True)]
    mocker.patch('mylib.func', side_effect=ret)
    ...
```