### PR TITLE
Use PEP-0426 environment markers to build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,5 @@
-import sys
-
 from setuptools import setup
 
-
-dependencies = ['pytest>=2.4']
-if sys.version_info < (3, 3):
-    dependencies.append('mock')
 
 setup(
     name='pytest-mock',
@@ -15,7 +9,12 @@ setup(
     },
     py_modules=['pytest_mock'],
     platforms='any',
-    install_requires=dependencies,
+    install_requires=[
+        'pytest>=2.4',
+    ],
+    extras_require={
+        ':python_version<"3.3"': ['mock'],
+    },
     url='https://github.com/pytest-dev/pytest-mock/',
     license='LGPL',
     author='Bruno Oliveira',


### PR DESCRIPTION
PEP-0426 defines [environment markers][] to allow wheels to conditionally install dependencies. This won't work with really old versions of setuptools/pip, but it works with pip 1.5.6 and newer.

[environment markers]: https://www.python.org/dev/peps/pep-0426/#environment-markers