### PR TITLE
Rename internal method parameter to avoid clashes with user methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,13 @@
   is now accessible from ``mocker``.
   Thanks `@satyrius`_ for the PR (`#32`_).
 
+* Fix regression using one of the ``assert_*`` methods in patched
+  functions which receive a parameter named ``method``.
+  Thanks `@sagarchalise`_ for the report (`#31`_).
+
+.. _@sagarchalise: https://github.com/sagarchalise
 .. _@satyrius: https://github.com/satyrius
+.. _#31: https://github.com/pytest-dev/pytest-mock/issues/31
 .. _#32: https://github.com/pytest-dev/pytest-mock/issues/32
 
 0.10.1

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -145,10 +145,10 @@ _mock_module_patches = []
 _mock_module_originals = {}
 
 
-def assert_wrapper(method, *args, **kwargs):
+def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
     __tracebackhide__ = True
     try:
-        method(*args, **kwargs)
+        __wrapped_mock_method__(*args, **kwargs)
     except AssertionError as e:
         raise AssertionError(*e.args)
 

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -4,8 +4,8 @@ import sys
 from contextlib import contextmanager
 
 import py.code
-import pytest
 
+import pytest
 
 pytest_plugins = 'pytester'
 
@@ -347,3 +347,18 @@ def test_parse_ini_boolean(testdir):
     assert pytest_mock.parse_ini_boolean('false') is False
     with pytest.raises(ValueError):
         pytest_mock.parse_ini_boolean('foo')
+
+
+def test_patched_method_parameter_name(mocker):
+    """Test that our internal code uses uncommon names when wrapping other
+    "mock" methods to avoid conflicts with user code (#31).
+    """
+
+    class Request:
+        @classmethod
+        def request(cls, method, args):
+            pass
+
+    m = mocker.patch.object(Request, 'request')
+    Request.request(method='get', args={'type': 'application/json'})
+    m.assert_called_once_with(method='get', args={'type': 'application/json'})


### PR DESCRIPTION
Fix #31