### PR TITLE
Show detailed py.test assert introspect for call arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,16 @@ your ``pytest.ini`` file:
     [pytest]
     mock_traceback_monkeypatch = false
 
+The plugin also adds introspection information on differing call arguments when
+calling the helper methods. This features catches `AssertionError` raised in
+the method, and uses py.test's own `advanced assertions`_ to return a better
+diff.
+
+This is useful when asserting mock calls with many/nested arguments and trying
+to quickly see the difference.
+
+.. _advanced assertions: https://pytest.org/latest/assert.html
+
 
 Requirements
 ============

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -154,6 +154,11 @@ def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
     try:
         __wrapped_mock_method__(*args, **kwargs)
     except AssertionError as e:
+        __mock_self = args[0]
+        if __mock_self.call_args is not None:
+            actual_args, actual_kwargs = __mock_self.call_args
+            assert actual_args == args[1:]
+            assert actual_kwargs == kwargs
         raise AssertionError(*e.args)
 
 
@@ -189,7 +194,8 @@ def wrap_assert_any_call(*args, **kwargs):
 
 def wrap_assert_methods(config):
     """
-    Wrap assert methods of mock module so we can hide their traceback
+    Wrap assert methods of mock module so we can hide their traceback and
+    add introspection information to specified argument asserts.
     """
     # Make sure we only do this once
     if _mock_module_originals:


### PR DESCRIPTION
## Why do this

I really enjoy pytest's assertion introspection support, and find it invaluable when it comes to comparing large pieces of data. However, when asserting mock calls with large arguments, I found myself copy-pasting objects into [`deepdiff`][1] just to more easily see the difference.

## Implementation

This may not be a complete solution, but it's the simplest I could think of to start discussing the point.

Among other improvements, we could also check `--assert` mode option, use [a custom assertion comparison][2] and [`raise_from`][3] original mock assertion.

Please let me know what you think about this feature?

[1]: https://pypi.python.org/pypi/deepdiff
[2]: https://pytest.org/latest/assert.html#defining-your-own-assertion-comparison
[3]: https://docs.python.org/3/library/exceptions.html#built-in-exceptions