### PR TITLE
spy: handle AttributeError with __getattribute__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,14 @@
   functions which receive a parameter named ``method``.
   Thanks `@sagarchalise`_ for the report (`#31`_).
 
+* Fix AttributeError with ``mocker.spy`` when spying on inherited methods
+  (`#42`_).
+
 .. _@sagarchalise: https://github.com/sagarchalise
 .. _@satyrius: https://github.com/satyrius
 .. _#31: https://github.com/pytest-dev/pytest-mock/issues/31
 .. _#32: https://github.com/pytest-dev/pytest-mock/issues/32
+.. _#42: https://github.com/pytest-dev/pytest-mock/issues/42
 
 0.10.1
 ------

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -60,11 +60,15 @@ class MockFixture(object):
         # Can't use autospec classmethod or staticmethod objects
         # see: https://bugs.python.org/issue23078
         if inspect.isclass(obj):
-            # bypass class descriptor:
+            # Bypass class descriptor:
             # http://stackoverflow.com/questions/14187973/python3-check-if-method-is-static
-            value = obj.__getattribute__(obj, name)
-            if isinstance(value, (classmethod, staticmethod)):
-                autospec = False
+            try:
+                value = obj.__getattribute__(obj, name)
+            except AttributeError:
+                pass
+            else:
+                if isinstance(value, (classmethod, staticmethod)):
+                    autospec = False
 
         result = self.patch.object(obj, name, side_effect=method,
                                    autospec=autospec)

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -212,12 +212,51 @@ def test_instance_method_by_class_spy(mocker):
 
 
 @skip_pypy
+def test_instance_method_by_subclass_spy(mocker):
+    from pytest_mock import mock_module
+
+    class Base(object):
+
+        def bar(self, arg):
+            return arg * 2
+
+    class Foo(Base):
+        pass
+
+    spy = mocker.spy(Foo, 'bar')
+    foo = Foo()
+    other = Foo()
+    assert foo.bar(arg=10) == 20
+    assert other.bar(arg=10) == 20
+    calls = [mock_module.call(foo, arg=10), mock_module.call(other, arg=10)]
+    assert spy.call_args_list == calls
+
+
+@skip_pypy
 def test_class_method_spy(mocker):
     class Foo(object):
 
         @classmethod
         def bar(cls, arg):
             return arg * 2
+
+    spy = mocker.spy(Foo, 'bar')
+    assert Foo.bar(arg=10) == 20
+    Foo.bar.assert_called_once_with(arg=10)
+    spy.assert_called_once_with(arg=10)
+
+
+@skip_pypy
+@pytest.mark.xfail(sys.version_info[0] == 2, reason='does not work on Python 2')
+def test_class_method_subclass_spy(mocker):
+    class Base(object):
+
+        @classmethod
+        def bar(self, arg):
+            return arg * 2
+
+    class Foo(Base):
+        pass
 
     spy = mocker.spy(Foo, 'bar')
     assert Foo.bar(arg=10) == 20
@@ -251,6 +290,24 @@ def test_static_method_spy(mocker):
         @staticmethod
         def bar(arg):
             return arg * 2
+
+    spy = mocker.spy(Foo, 'bar')
+    assert Foo.bar(arg=10) == 20
+    Foo.bar.assert_called_once_with(arg=10)
+    spy.assert_called_once_with(arg=10)
+
+
+@skip_pypy
+@pytest.mark.xfail(sys.version_info[0] == 2, reason='does not work on Python 2')
+def test_static_method_subclass_spy(mocker):
+    class Base(object):
+
+        @staticmethod
+        def bar(arg):
+            return arg * 2
+
+    class Foo(Base):
+        pass
 
     spy = mocker.spy(Foo, 'bar')
     assert Foo.bar(arg=10) == 20


### PR DESCRIPTION
I have noticed that `spy` did not work on functions that are not defined
in the class itself, but a parent class.  This patch fixes this.