### PR TITLE
Re-add Python 3.3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Testing',

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -273,8 +273,8 @@ def assert_traceback():
         raise AssertionError("DID NOT RAISE")
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 4),
-                    reason="assert_not_called not available in python 3.4")
+@pytest.mark.skipif(sys.version_info[0] == 3 and sys.version_info[1] in (3, 4),
+                    reason="assert_not_called not available in python 3.3 and 3.4")
 def test_assert_not_called_wrapper(mocker):
     stub = mocker.stub()
     stub.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # note that tox expects interpreters to be found at C:\PythonXY,
 # with XY being python version ("27" or "34") for instance
-envlist = py{26,27,34,35}-pytest{27,28},linting
+envlist = py{26,27,33,34,35}-pytest{27,28},linting
 
 [testenv]
 passenv = USER USERNAME


### PR DESCRIPTION
Python 3.3 and 3.2 were de-supported in v0.8.1 (9da34539).