### PR TITLE
Disable monkey patching "mock" when --tb is set to native

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,16 @@
   ``repr`` string as well as related assertion failure messages.
   Thanks `@jurko-gospodnetic`_ for the PR (`#40`_).
 
+* Monkey patching is automatically disabled with the ``--tb=native`` option. The underlying
+  mechanism used to suppress traceback entries from ``mock`` module does not work with that option
+  anyway plus it generates confusing messages on Python 3.5 due to exception chaining (`#44`_).
+  Thanks `@blueyed`_ for the report.
+
 .. _@jurko-gospodnetic: https://github.com/jurko-gospodnetic
 .. _@asfaltboy: https://github.com/asfaltboy
-.. _#40: https://github.com/pytest-dev/pytest-mock/issues/40
 .. _#36: https://github.com/pytest-dev/pytest-mock/issues/36
+.. _#40: https://github.com/pytest-dev/pytest-mock/issues/40
+.. _#44: https://github.com/pytest-dev/pytest-mock/issues/44
 
 1.0
 ---

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -252,5 +252,6 @@ def parse_ini_boolean(value):
 
 
 def pytest_configure(config):
-    if parse_ini_boolean(config.getini('mock_traceback_monkeypatch')):
+    tb = config.getoption('--tb')
+    if parse_ini_boolean(config.getini('mock_traceback_monkeypatch')) and tb != 'native':
         wrap_assert_methods(config)


### PR DESCRIPTION
The mechanism we use to hide traceback entries from the `mock` module does not work on native tracebacks anyway, so it makes sense to automatically disable it in that situation.

This also takes care of the duplicated tracebacks on Python 3.5. @blueyed could you try this out and tell what do you think?

Fix #44 