### PR TITLE
Try to import "mock" before "unittest.mock"

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -3,10 +3,10 @@ import sys
 
 import pytest
 
-if sys.version_info >= (3, 3): # pragma: no cover
-    import unittest.mock as mock_module
-else:
+try:
     import mock as mock_module
+except ImportError:
+    import unittest.mock as mock_module
 
 version = '1.1'
 


### PR DESCRIPTION
I have hit a bug in mock that is fixed in the version of mock included
with Python 3.5.1 but present in 3.3.5 (fixed indirectly in
testing-cabal/mock@eba505cf3e). I can install the fixed "mock" package from
PyPI, but because `pytest_mock` only uses `unittest.mock` for Python
3.3+, the fixed package has no effect.

Instead of trying to check versions, I take the EAFP approach and just
try to import `mock` and fall back to `unittest.mock`. It is possible
that an old version of "mock" could be installed with a newer Python,
but that seems easier to fix than the reverse.