### PR TITLE
Added "mock.sentinel" to the "mocker" fixture for convenience.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@
   to install a newer ``mock`` version from PyPI instead of using the one available in the
   Python distribution.
   Thanks `@wcooley`_ for the PR (`#54`_).
+* ``mock.sentinel`` is now aliased as ``mocker.sentinel`` for convenience.
 
 .. _@wcooley: https://github.com/wcooley
 .. _#54: https://github.com/pytest-dev/pytest-mock/issues/54  

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Some objects from the ``mock`` module are accessible directly from ``mocker`` fo
 * `PropertyMock <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock>`_
 * `ANY <https://docs.python.org/3/library/unittest.mock.html#any>`_
 * `call <https://docs.python.org/3/library/unittest.mock.html#call>`_ *(Version 1.1)*
+* `sentinel <https://docs.python.org/3/library/unittest.mock.html#sentinel>`_ *(Version 1.2)*
 
 
 Spy

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -21,6 +21,7 @@ class MockFixture(object):
     PropertyMock = mock_module.PropertyMock
     call = mock_module.call
     ANY = mock_module.ANY
+    sentinel = mock_module.sentinel
 
     def __init__(self):
         self._patches = []  # list of mock._patch objects

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -132,7 +132,7 @@ def test_deprecated_mock(mock, tmpdir):
     assert os.listdir(str(tmpdir)) == []
 
 
-@pytest.mark.parametrize('name', ['MagicMock', 'PropertyMock', 'Mock', 'call', 'ANY'])
+@pytest.mark.parametrize('name', ['MagicMock', 'PropertyMock', 'Mock', 'call', 'ANY', 'sentinel'])
 def test_mocker_aliases(name):
     from pytest_mock import mock_module, MockFixture
 


### PR DESCRIPTION
Given that there is already some precedence for this sort of thing, it would be very convenient to be able to access `mock.sentinel` off of the `mocker` fixture.

I added this, updated the docs, updated the changelog, and added a test case (just adding a parameter to an existing parameterized test).

Please let me know whether or not this is a change you like, and if yes, if there's anything more I need to do to have this PR accepted.

Thanks!