### PR TITLE
Feature: descriptive mock assert wrap

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -159,8 +159,12 @@ def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
         __mock_self = args[0]
         if __mock_self.call_args is not None:
             actual_args, actual_kwargs = __mock_self.call_args
-            assert actual_args == args[1:]
-            assert actual_kwargs == kwargs
+            try:
+                assert (args[1:], kwargs) == (actual_args, actual_kwargs)
+            except AssertionError as detailed_comparison:
+                e.args = (e.msg + "\n\n... pytest introspection follows:\n" +
+                          detailed_comparison.msg, )
+                print(e.args)
         raise AssertionError(*e.args)
 
 

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -229,7 +229,7 @@ def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
     except AssertionError as e:
         __mock_self = args[0]  # the mock instance
         assert_call = mock_module.call(*args[1:], **kwargs)
-        if __mock_self.call_args is not None:
+        if __mock_self.call_args is not None and not hasattr(e, '_msg_updated'):
             try:
                 if __wrapped_mock_method__.__name__ == 'assert_any_call':
                     assert assert_call in __mock_self.call_args_list
@@ -239,7 +239,9 @@ def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
             except AssertionError as diff:
                 # raise a new detailed exception, appending to existing
                 msg = DETAILED_ASSERTION.format(original=e, detailed=diff)
-                raise AssertionError(msg.encode().decode('unicode_escape'))
+                err = AssertionError(msg.encode().decode('unicode_escape'))
+                err._msg_updated = True
+                raise err
         raise e
 
 

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -2,7 +2,6 @@ from pprint import pformat
 import inspect
 
 import pytest
-import py
 
 try:
     import mock as mock_module
@@ -221,7 +220,7 @@ def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
                 err = AssertionError(msg.encode().decode('unicode_escape'))
                 err._msg_updated = True
                 raise err
-        raise e
+        raise AssertionError(*e.args)
 
 
 def wrap_assert_not_called(*args, **kwargs):

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -158,7 +158,7 @@ DETAILED_ASSERTION = """{original!s}
 ... pytest introspection follows:
 {detailed!s}
 """
-FULL_ANY_CALLS_DIFF = "assert {call} in {calls_list}"
+FULL_ANY_CALLS_DIFF = "{call} in {calls_list}"
 
 
 def pytest_assertrepr_compare(config, op, left, right):
@@ -173,9 +173,6 @@ def pytest_assertrepr_compare(config, op, left, right):
         call_class = mock_module._Call
         call_list_class = mock_module._CallList
 
-    verbose = config.getoption('verbose')
-    u = py.builtin._totext
-
     def safe_unpack_args(call):
         try:
             args, kwargs = call
@@ -183,43 +180,25 @@ def pytest_assertrepr_compare(config, op, left, right):
             name, args, kwargs = call
         return args, kwargs
 
-    def get_summary():
-        width = 80 - 15 - len(op) - 2  # 15 chars indentation, 1 space around op
-        left_repr = py.io.saferepr(left, maxsize=int(width / 2))
-        right_repr = py.io.saferepr(right, maxsize=width - len(left_repr))
-
-        def ecu(s):
-            try:
-                return u(s, 'utf-8', 'replace')
-            except TypeError:
-                return s
-        return u('%s %s %s') % (ecu(left_repr), op, ecu(right_repr))
-
-    summary = get_summary()
-    if not verbose:
-        return [summary, u('Use -v to get the full diff')]
-
-    from _pytest.assertion.util import assertrepr_compare
     if isinstance(left, call_class) and isinstance(right, call_class) and op == '==':
         largs, lkwargs = safe_unpack_args(left)
         rargs, rkwargs = safe_unpack_args(right)
-        explanation = ['Full diff:']
 
-        arg_expl = assertrepr_compare(config, op, largs, rargs)
-        if arg_expl:
-            explanation += ['positional arguments differ;'] + arg_expl
-        kwarg_expl = assertrepr_compare(config, op, lkwargs, rkwargs)
-        if kwarg_expl:
-            explanation += ['keyword arguments differ;'] + kwarg_expl
+        msg = []
+        try:
+            assert largs == rargs
+        except AssertionError as e:
+            msg.extend(['args introspection:', str(e)])
 
-        return [summary] + explanation
+        try:
+            assert lkwargs == rkwargs
+        except AssertionError as e:
+            msg.extend(['kwargs introspection:', str(e)])
+        return msg
 
     if (isinstance(left, tuple) and
             isinstance(right, call_list_class) and op == "in"):
-        return [
-            summary, u('Full diff:'),
-            FULL_ANY_CALLS_DIFF.format(call=left, calls_list=pformat(right))
-        ]
+        return [FULL_ANY_CALLS_DIFF.format(call=left, calls_list=pformat(right))]
 
 
 def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -1,12 +1,15 @@
 from pprint import pformat
 import inspect
 
+import py
 import pytest
 
 try:
     import mock as mock_module
 except ImportError:
     import unittest.mock as mock_module
+
+u = py.builtin._totext
 
 version = '1.2'
 
@@ -152,12 +155,12 @@ _mock_module_patches = []
 _mock_module_originals = {}
 
 
-DETAILED_ASSERTION = """{original!s}
+DETAILED_ASSERTION = u("""{original!s}
 
 ... pytest introspection follows:
 {detailed!s}
-"""
-FULL_ANY_CALLS_DIFF = "{call} in {calls_list}"
+""")
+FULL_ANY_CALLS_DIFF = u("{call} in {calls_list}")
 
 
 def pytest_assertrepr_compare(config, op, left, right):
@@ -187,12 +190,12 @@ def pytest_assertrepr_compare(config, op, left, right):
         try:
             assert largs == rargs
         except AssertionError as e:
-            msg.extend(['args introspection:', str(e)])
+            msg.extend(['args introspection:', u(e)])
 
         try:
             assert lkwargs == rkwargs
         except AssertionError as e:
-            msg.extend(['kwargs introspection:', str(e)])
+            msg.extend(['kwargs introspection:', u(e)])
         return msg
 
     if (isinstance(left, tuple) and
@@ -216,8 +219,8 @@ def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
                     assert assert_call == __mock_self.call_args
             except AssertionError as diff:
                 # raise a new detailed exception, appending to existing
-                msg = DETAILED_ASSERTION.format(original=e, detailed=diff)
-                err = AssertionError(msg.encode().decode('unicode_escape'))
+                msg = DETAILED_ASSERTION.format(original=u(e), detailed=u(diff))
+                err = AssertionError(msg.replace('\\n', '\n').encode('unicode_escape').decode('unicode_escape'))
                 err._msg_updated = True
                 raise err
         raise AssertionError(*e.args)

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -515,14 +515,37 @@ def test_assertion_error_is_descriptive(mocker):
     mocker_mock(a=1, b=2)
     mock_mock(a=1, b=2)
 
+    # arguments assertion for last call
     try:
         mocker_mock.assert_called_once_with(1, 2)
     except AssertionError as e:
-        mocker_error_message = e.msg
+        mocker_called_once_with = e.msg
+    try:
+        mocker_mock.assert_called_with(1, 2)
+    except AssertionError as e:
+        mocker_called_with = e.msg
 
     try:
         assert_called_with(mock_mock, 1, 2)
     except AssertionError as e:
         mock_error_message = e.msg
 
-    assert mocker_error_message.startswith(mock_error_message)
+    assert mocker_called_once_with.startswith(mock_error_message)
+    mocker_mock(a='foo', b='bar')
+    assert mocker_called_with.startswith(mock_error_message)
+    assert "assert call((1, 2), {}) ==" in mocker_called_with
+
+    # argument assertion for any call (with multiline call list)
+    assert_any_call = _mock_module_originals['assert_any_call']
+    try:
+        mocker_mock.assert_any_call(1, 2)
+    except AssertionError as e:
+        mocker_any_call = e.msg
+
+    try:
+        assert_any_call(mock_mock, 1, 2)
+    except AssertionError as e:
+        mock_error_message = e.msg
+
+    assert mocker_any_call.startswith(mock_error_message)
+    assert "assert call((1, 2), {}) in [" in mocker_any_call

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -77,8 +77,7 @@ def mock_using_patch_multiple(mocker):
 
 
 @pytest.mark.parametrize('mock_fs', [mock_using_patch_object, mock_using_patch,
-                                     mock_using_patch_multiple],
-)
+                                     mock_using_patch_multiple], )
 def test_mock_patches(mock_fs, mocker, check_unix_fs_mocked):
     """
     Installs mocks into `os` functions and performs a standard testing of
@@ -163,7 +162,7 @@ class TestMockerStub:
 
     def test_repr_with_no_name(self, mocker):
         stub = mocker.stub()
-        assert not 'name' in repr(stub)
+        assert 'name' not in repr(stub)
 
     def test_repr_with_name(self, mocker):
         test_name = 'funny walk'
@@ -503,8 +502,12 @@ def test_monkeypatch_native(testdir):
 
 def test_assertion_error_is_descriptive(mocker):
     """Verify assert_wrapper starts with original call comparison error msg"""
-    import mock
+    try:
+        import mock
+    except ImportError:
+        from unittest import mock
     from pytest_mock import _mock_module_originals
+
     mocker_mock = mocker.patch('os.remove')
     mock_mock = mock.patch('os.remove').start()  # use same func name
     assert_called_with = _mock_module_originals['assert_called_with']

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -538,7 +538,8 @@ def test_assertion_error_is_descriptive(mocker):
         assert "{} == {'a': 1, 'b': 2}" in mocker_called_with
     else:
         print(mocker_called_with)
-        assert 'assert call(1, 2) == call(' in mocker_called_with
+        assert 'Expected call: remove(1, 2)' in mocker_called_with
+        assert "assert {} == {'a': 1, 'b': 2}" in mocker_called_with
         assert 'Use -v to get the full diff' in mocker_called_with
 
     # argument assertion for any call (with multiline call list)

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,17 @@ deps =
     pytest28: pytest==2.8.7
 commands = coverage run --append --source=pytest_mock.py -m pytest test_pytest_mock.py
 
+[testenv:py26]
+deps =
+    mock
 
 [testenv:linting]
 basepython = python3.5
 skip_install=True
 deps =
     pytest-flakes
-    restructuredtext_lint 
+    restructuredtext_lint
     pygments
 commands =
     py.test --flakes pytest_mock.py test_pytest_mock.py -m flakes
-    rst-lint CHANGELOG.rst README.rst    
+    rst-lint CHANGELOG.rst README.rst


### PR DESCRIPTION
This branch adds original call assertion error message and improves result message. Here is a detailed list of changes:
- assert both args and kwargs at the same time for a more detailed report
- update tests to assert the above
- re-raise original AssertionError implicitly
- define a DETAILED_ASSERTION template to format the detailed message
- add mock to py26 dependencies in tox.ini
- use unittest.mock for py > 3.3
- small style cleanup (PEP8)

Attempts to improve on PR #36 according to the points raised in PR #57
