### PR TITLE
Update tests to work with pytest 3

### DIFF
--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -176,7 +176,7 @@ class TestMockerStub:
         stub = mocker.stub(**kwargs)
         with pytest.raises(AssertionError) as exc_info:
             stub.assert_called_with()
-        assert exc_info.value.msg == expected_message
+        assert str(exc_info.value) == expected_message
 
     def test_failure_message_with_no_name(self, mocker):
         self.__test_failure_message(mocker)
@@ -352,7 +352,7 @@ def assert_argument_introspection(left, right):
         #       test was run by examining sys.argv
         verbose = any(a.startswith('-v') for a in sys.argv)
         expected = '\n  '.join(util._compare_eq_iterable(left, right, verbose))
-        assert expected in e.msg
+        assert expected in str(e)
     else:
         raise AssertionError("DID NOT RAISE")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # note that tox expects interpreters to be found at C:\PythonXY,
 # with XY being python version ("27" or "34") for instance
-envlist = py{26,27,33,34,35}-pytest{27,28},linting
+envlist = py{26,27,33,34,35}-pytest{27,28,30},linting
 
 [testenv]
 passenv = USER USERNAME
@@ -9,6 +9,7 @@ deps =
     coverage
     pytest27: pytest==2.7.3
     pytest28: pytest==2.8.7
+    pytest30: pytest==3.0.1
 commands = coverage run --append --source=pytest_mock.py -m pytest test_pytest_mock.py
 
 


### PR DESCRIPTION
Also update tox.ini to run them.

This is not complete as 2 tests are still failing. I don't grasp exactly why, but I suspect we get a regular `AssertionError()` because pytest didn't replace the `assert` at this point by its own one.

Related to #61.