### PR TITLE
remove duplicated assignment of self.sentinel and self.mock_open

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -45,8 +45,6 @@ class MockFixture(object):
         self.DEFAULT = mock_module.DEFAULT
         self.sentinel = mock_module.sentinel
         self.mock_open = mock_module.mock_open
-        self.sentinel = mock_module.sentinel
-        self.mock_open = mock_module.mock_open
 
     def resetall(self):
         """


### PR DESCRIPTION
I noticed this while I was browsing the source. Looks like a merge got screwed up at some point and these two lines got duplicated.