### PR TITLE
Only reset actual mocks in resetall().

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -124,7 +124,8 @@ class MockFixture(object):
             p = mock_func(*args, **kwargs)
             mocked = p.start()
             self._patches.append(p)
-            self._mocks.append(mocked)
+            if hasattr(mocked, 'reset_mock'):
+                self._mocks.append(mocked)
             return mocked
 
         def object(self, *args, **kwargs):

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -86,6 +86,8 @@ def test_mock_patches(mock_fs, mocker, check_unix_fs_mocked):
     mock_fs(mocker)
     mocked_rm, mocked_ls = mock_fs(mocker)
     check_unix_fs_mocked(mocked_rm, mocked_ls)
+    mocker.resetall()
+    mocker.stopall()
 
 
 def test_mock_patch_dict(mocker):
@@ -98,6 +100,18 @@ def test_mock_patch_dict(mocker):
     assert x == {'new': 10}
     mocker.stopall()
     assert x == {'original': 1}
+
+
+def test_mock_patch_dict_resetall(mocker):
+    """
+    We can call resetall after patching a dict.
+    :param mock:
+    """
+    x = {'original': 1}
+    mocker.patch.dict(x, values=[('new', 10)], clear=True)
+    assert x == {'new': 10}
+    mocker.resetall()
+    assert x == {'new': 10}
 
 
 def test_deprecated_mock(mock, tmpdir):


### PR DESCRIPTION
The `mocker.patch.dict` method currently causes `mocker.resetall()` to fail, because `patch.dict` does not return a mock that can be reset.

* Only append the return value of the patching function to the list of outstanding mocks if it has the `reset_mock` attribute.
* Add a test verifying we can call `resetall()` after patching a dict.
* Add a test verifying we can call `resetall()` and `stopall()` after other patching methods.