### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 
+from io import open
 
 setup(
     name='pytest-mock',
@@ -20,7 +21,7 @@ setup(
     author='Bruno Oliveira',
     author_email='nicoddemus@gmail.com',
     description='Thin-wrapper around the mock package for easier use with py.test',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', encoding='utf-8').read(),
     keywords="pytest mock",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Otherwise, the build fails with an encoding error due to the default locale being ASCII on the Debian builders, not UTF-8. Regardless, this is the recommended approach for writing a `setup.py` which supports both Python 2 and Python 3.