### PR TITLE
Dont use EMOJI in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ of a test:
   :target: http://www.opensourcecitizen.org/project?url=github.com/pytest-dev/pytest-mock
 
 If you found this library useful, donate some CPU cycles to its
-development efforts by clicking above. Thank you! 😇  
+development efforts by clicking above. Thank you!
 
 Usage
 =====


### PR DESCRIPTION
Fixes:
    /usr/bin/python3 setup.py build '--executable=/usr/bin/python3 -s'
    Traceback (most recent call last):
         File "setup.py", line 23, in <module>
             long_description=open('README.rst').read(),
         File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
             return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 1820: ordinal not in range(128)