### PR TITLE
Adds missing aliases for NonCallableMock and create_autospec

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -48,6 +48,7 @@ class MockFixture(object):
         # aliases for convenience
         self.Mock = mock_module.Mock
         self.MagicMock = mock_module.MagicMock
+        self.NonCallableMock = mock_module.NonCallableMock
         self.PropertyMock = mock_module.PropertyMock
         self.call = mock_module.call
         self.ANY = mock_module.ANY

--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -53,6 +53,7 @@ class MockFixture(object):
         self.call = mock_module.call
         self.ANY = mock_module.ANY
         self.DEFAULT = mock_module.DEFAULT
+        self.create_autospec = mock_module.create_autospec
         self.sentinel = mock_module.sentinel
         self.mock_open = mock_module.mock_open
 

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -137,7 +137,7 @@ def test_deprecated_mock(mock, tmpdir):
     assert os.listdir(str(tmpdir)) == []
 
 
-@pytest.mark.parametrize('name', ['MagicMock', 'PropertyMock', 'Mock', 'call', 'ANY', 'sentinel', 'mock_open'])
+@pytest.mark.parametrize('name', ['MagicMock', 'NonCallableMock', 'PropertyMock', 'Mock', 'call', 'ANY', 'sentinel', 'mock_open'])
 def test_mocker_aliases(name, pytestconfig):
     from pytest_mock import _get_mock_module, MockFixture
 

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -137,7 +137,7 @@ def test_deprecated_mock(mock, tmpdir):
     assert os.listdir(str(tmpdir)) == []
 
 
-@pytest.mark.parametrize('name', ['MagicMock', 'NonCallableMock', 'PropertyMock', 'Mock', 'call', 'ANY', 'sentinel', 'mock_open'])
+@pytest.mark.parametrize('name', ['MagicMock', 'NonCallableMock', 'PropertyMock', 'Mock', 'call', 'ANY', 'create_autospec', 'sentinel', 'mock_open'])
 def test_mocker_aliases(name, pytestconfig):
     from pytest_mock import _get_mock_module, MockFixture
 


### PR DESCRIPTION
This PR is adding support for the following missing aliases:
* `NonCallableMock` :: (https://docs.python.org/3/library/unittest.mock.html#unittest.mock.NonCallableMock)
* `create_autospec` :: https://docs.python.org/3/library/unittest.mock.html#create-autospec

It simply adds the missing instantiation into `MockFixture` and adds it also into the corresponding test.