### PR TITLE
Add support for `assert_called_once()`

### DIFF
--- a/pytest_mock.py
+++ b/pytest_mock.py
@@ -221,6 +221,12 @@ def wrap_assert_called_with(*args, **kwargs):
                    *args, **kwargs)
 
 
+def wrap_assert_called_once(*args, **kwargs):
+    __tracebackhide__ = True
+    assert_wrapper(_mock_module_originals["assert_called_once"],
+                   *args, **kwargs)
+
+
 def wrap_assert_called_once_with(*args, **kwargs):
     __tracebackhide__ = True
     assert_wrapper(_mock_module_originals["assert_called_once_with"],
@@ -254,6 +260,7 @@ def wrap_assert_methods(config):
         'assert_not_called': wrap_assert_not_called,
         'assert_called_with': wrap_assert_called_with,
         'assert_called_once_with': wrap_assert_called_once_with,
+        'assert_called_once': wrap_assert_called_once,
         'assert_has_calls': wrap_assert_has_calls,
         'assert_any_call': wrap_assert_any_call,
     }

--- a/test_pytest_mock.py
+++ b/test_pytest_mock.py
@@ -388,6 +388,17 @@ def test_assert_called_once_with_wrapper(mocker):
         stub.assert_called_once_with("foo")
 
 
+def test_assert_called_once_wrapper(mocker):
+    stub = mocker.stub()
+    if not hasattr(stub, 'assert_called_once'):
+        pytest.skip('assert_called_once not available')
+    stub("foo")
+    stub.assert_called_once()
+    stub("foo")
+    with assert_traceback():
+        stub.assert_called_once()
+
+
 @pytest.mark.usefixtures('needs_assert_rewrite')
 def test_assert_called_args_with_introspection(mocker):
     stub = mocker.stub()


### PR DESCRIPTION
This was added in Python 3.6.

ref: https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.assert_called_once