### PR TITLE
Do not show "pytest introspection" msg when there is no introspection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
-1.11.1
-------
+1.11.2 (unreleased)
+-------------------
+
+* The *pytest introspection follows* message is no longer shown
+  if there is no pytest introspection (`#154`_).
+  Thanks `@The-Compiler`_ for the report.
+
+.. _#154: https://github.com/pytest-dev/pytest-mock/issues/154
+
+1.11.1 (2019-10-04)
+-------------------
 
 * Fix ``mocker.spy`` on Python 2 when used on non-function objects
   which implement ``__call__`` (`#157`_). Thanks `@pbasista`_  for

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -212,15 +212,18 @@ def assert_wrapper(__wrapped_mock_method__, *args, **kwargs):
             msg = text_type(e)
             if __mock_self.call_args is not None:
                 actual_args, actual_kwargs = __mock_self.call_args
-                msg += "\n\npytest introspection follows:\n"
+                introspection = ""
                 try:
                     assert actual_args == args[1:]
                 except AssertionError as e:
-                    msg += "\nArgs:\n" + text_type(e)
+                    introspection += "\nArgs:\n" + text_type(e)
                 try:
                     assert actual_kwargs == kwargs
                 except AssertionError as e:
-                    msg += "\nKwargs:\n" + text_type(e)
+                    introspection += "\nKwargs:\n" + text_type(e)
+
+                if introspection:
+                    msg += "\n\npytest introspection follows:\n" + introspection
     e = AssertionError(msg)
     e._mock_introspection_applied = True
     raise e

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -679,6 +679,20 @@ def test_detailed_introspection(testdir):
     result.stdout.fnmatch_lines(expected_lines)
 
 
+def test_missing_introspection(testdir):
+    testdir.makepyfile(
+        """
+        def test_foo(mocker):
+            mock = mocker.Mock()
+            mock('foo')
+            mock('test')
+            mock.assert_called_once_with('test')
+    """
+    )
+    result = testdir.runpytest()
+    assert "pytest introspection follows:" not in result.stdout.str()
+
+
 def test_assert_called_with_unicode_arguments(mocker):
     """Test bug in assert_call_with called with non-ascii unicode string (#91)"""
     stub = mocker.stub()


### PR DESCRIPTION
Fix #154