### PR TITLE
Raise error if any version of patch is used as a context manager

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -147,6 +147,7 @@ class MockFixture(object):
             module, registering the patch to stop it later and returns the
             mock object resulting from the mock call.
             """
+            self._enforce_no_with_context(inspect.stack())
             p = mock_func(*args, **kwargs)
             mocked = p.start()
             self._patches.append(p)
@@ -154,14 +155,9 @@ class MockFixture(object):
                 self._mocks.append(mocked)
             return mocked
 
-        def object(self, *args, **kwargs):
-            """API to mock.patch.object"""
-            self._enforce_no_with_context(inspect.stack())
-            return self._start_patch(self.mock_module.patch.object, *args, **kwargs)
-
         def _enforce_no_with_context(self, stack):
             """raises a ValueError if mocker is used in a with context"""
-            caller = stack[1]
+            caller = stack[2]
             frame = caller[0]
             info = inspect.getframeinfo(frame)
             code_context = " ".join(info.code_context).strip()
@@ -171,6 +167,10 @@ class MockFixture(object):
                     "Using mocker in a with context is not supported. "
                     "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager"
                 )
+
+        def object(self, *args, **kwargs):
+            """API to mock.patch.object"""
+            return self._start_patch(self.mock_module.patch.object, *args, **kwargs)
 
         def multiple(self, *args, **kwargs):
             """API to mock.patch.multiple"""

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -723,7 +723,7 @@ def test_plain_stopall(testdir):
     assert "RuntimeError" not in result.stderr.str()
 
 
-def test_abort_context_manager(mocker):
+def test_abort_patch_object_context_manager(mocker):
     class A(object):
         def doIt(self):
             return False
@@ -733,6 +733,19 @@ def test_abort_context_manager(mocker):
     with pytest.raises(ValueError) as excinfo:
         with mocker.patch.object(a, "doIt", return_value=True):
             assert a.doIt() == True
+
+    expected_error_msg = (
+        "Using mocker in a with context is not supported. "
+        "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager"
+    )
+
+    assert str(excinfo.value) == expected_error_msg
+
+
+def test_abort_patch_context_manager(mocker):
+    with pytest.raises(ValueError) as excinfo:
+        with mocker.patch("some_package"):
+            pass
 
     expected_error_msg = (
         "Using mocker in a with context is not supported. "


### PR DESCRIPTION
On #165, a change was added to raise an Exception when trying to use `mocker.patch.object` as a context manager, as its behavior is not supported in the plugin. However, the context managers for the remaining patch options (`dict`, `multiple`, and normal `patch`) still work as usual.

With this change, we check if we are in a context manager when starting the patch, so all the methods will raise the exception when corresponds.