### PR TITLE
Handle 'mocker.patch' being used without source code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+1.12.1 (2019-11-20)
+-------------------
+
+* Fix error if ``mocker.patch`` is used in code where the source file
+  is not available, for example stale ``.pyc`` files (`#169`_).
+
+.. _#169: https://github.com/pytest-dev/pytest-mock/issues/169#issuecomment-555729265
+
 1.12.0 (2019-11-19)
 -------------------
 

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -160,6 +160,9 @@ class MockFixture(object):
             caller = stack[2]
             frame = caller[0]
             info = inspect.getframeinfo(frame)
+            if info.code_context is None:
+                # no source code available (#169)
+                return
             code_context = " ".join(info.code_context).strip()
 
             if code_context.startswith("with mocker."):


### PR DESCRIPTION
Fix #169