### PR TITLE
Spy exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+1.13.0
+------
+
+* The object returned by ``mocker.spy`` now also tracks any side effect
+  of the spied method/function.
+
 1.12.1 (2019-11-20)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-1.13.0
-------
+1.13.0 (2019-12-05)
+-------------------
 
 * The object returned by ``mocker.spy`` now also tracks any side effect
   of the spied method/function.

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,9 @@ features with it, like retrieving call count. It also works for class and static
 Since version ``1.11``, it is also possible to query the ``return_value`` attribute
 to observe what the spied function/method returned.
 
+Since version ``1.13``, it is also possible to query the ``side_effect`` attribute
+to observe any exception thrown by the spied function/method.
+
 Stub
 ----
 

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -116,7 +116,7 @@ class MockFixture(object):
             try:
                 r = method(*args, **kwargs)
             except Exception as e:
-                result.return_value = e
+                result.side_effect = e
                 raise
             else:
                 result.return_value = r

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -113,8 +113,13 @@ class MockFixture(object):
 
         @w
         def wrapper(*args, **kwargs):
-            r = method(*args, **kwargs)
-            result.return_value = r
+            try:
+                r = method(*args, **kwargs)
+            except Exception as e:
+                result.return_value = e
+                raise
+            else:
+                result.return_value = r
             return r
 
         result = self.patch.object(obj, name, side_effect=wrapper, autospec=autospec)

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -245,6 +245,7 @@ def test_instance_method_spy(mocker):
 
 def test_instance_method_spy_exception(mocker):
     excepted_message = "foo"
+
     class Foo(object):
         def bar(self, arg):
             raise Exception(excepted_message)

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -259,7 +259,7 @@ def test_instance_method_spy_exception(mocker):
     assert str(exc_info.value) == excepted_message
 
     foo.bar.assert_called_once_with(arg=10)
-    assert spy.return_value == exc_info.value
+    assert spy.side_effect == exc_info.value
 
 
 @skip_pypy

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -243,6 +243,24 @@ def test_instance_method_spy(mocker):
     assert spy.return_value == 20
 
 
+def test_instance_method_spy_exception(mocker):
+    excepted_message = "foo"
+    class Foo(object):
+        def bar(self, arg):
+            raise Exception(excepted_message)
+
+    foo = Foo()
+    other = Foo()
+    spy = mocker.spy(foo, "bar")
+
+    with pytest.raises(Exception) as exc_info:
+        foo.bar(10)
+    assert str(exc_info.value) == excepted_message
+
+    foo.bar.assert_called_once_with(arg=10)
+    assert spy.return_value == exc_info.value
+
+
 @skip_pypy
 def test_instance_method_by_class_spy(mocker):
     class Foo(object):


### PR DESCRIPTION
On spied methods, we are capturing return value. However when exceptions are raised, `return_value` comes back as `False` rather than the exception itself.

This PR change stores the raised exception into the return value.