### PR TITLE
Add mocker for class, module, package and session scopes

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -199,8 +199,7 @@ class MockFixture:
             return self._start_patch(self.mock_module.patch, *args, **kwargs)
 
 
-@pytest.yield_fixture
-def mocker(pytestconfig):
+def _mocker(pytestconfig):
     """
     return an object that has the same interface to the `mock` module, but
     takes care of automatically undoing all patches after each test method.
@@ -208,6 +207,13 @@ def mocker(pytestconfig):
     result = MockFixture(pytestconfig)
     yield result
     result.stopall()
+
+
+mocker = pytest.yield_fixture()(_mocker)  # default scope is function
+class_mocker = pytest.yield_fixture(scope="class")(_mocker)
+module_mocker = pytest.yield_fixture(scope="module")(_mocker)
+package_mocker = pytest.yield_fixture(scope="package")(_mocker)
+session_mocker = pytest.yield_fixture(scope="session")(_mocker)
 
 
 _mock_module_patches = []

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -820,3 +820,97 @@ def test_abort_patch_context_manager_with_stale_pyc(testdir):
     py_fn.remove()
     result = testdir.runpytest()
     result.stdout.fnmatch_lines("* 1 passed *")
+
+
+def test_used_with_class_scope(testdir):
+    """..."""
+    testdir.makepyfile(
+        """
+        import pytest
+        import random
+        import unittest
+
+        def get_random_number():
+            return random.randint(0, 1)
+
+        @pytest.fixture(autouse=True, scope="class")
+        def randint_mock(class_mocker):
+            return class_mocker.patch("random.randint", lambda x, y: 5)
+
+        class TestGetRandomNumber(unittest.TestCase):
+            def test_get_random_number(self):
+                assert get_random_number() == 5
+    """
+    )
+    result = testdir.runpytest_subprocess()
+    assert "AssertionError" not in result.stderr.str()
+    result.stdout.fnmatch_lines("* 1 passed in *")
+
+
+def test_used_with_module_scope(testdir):
+    """..."""
+    testdir.makepyfile(
+        """
+        import pytest
+        import random
+
+        def get_random_number():
+            return random.randint(0, 1)
+
+        @pytest.fixture(autouse=True, scope="module")
+        def randint_mock(module_mocker):
+            return module_mocker.patch("random.randint", lambda x, y: 5)
+
+        def test_get_random_number():
+            assert get_random_number() == 5
+    """
+    )
+    result = testdir.runpytest_subprocess()
+    assert "AssertionError" not in result.stderr.str()
+    result.stdout.fnmatch_lines("* 1 passed in *")
+
+
+def test_used_with_package_scope(testdir):
+    """..."""
+    testdir.makepyfile(
+        """
+        import pytest
+        import random
+
+        def get_random_number():
+            return random.randint(0, 1)
+
+        @pytest.fixture(autouse=True, scope="package")
+        def randint_mock(package_mocker):
+            return package_mocker.patch("random.randint", lambda x, y: 5)
+
+        def test_get_random_number():
+            assert get_random_number() == 5
+    """
+    )
+    result = testdir.runpytest_subprocess()
+    assert "AssertionError" not in result.stderr.str()
+    result.stdout.fnmatch_lines("* 1 passed in *")
+
+
+def test_used_with_session_scope(testdir):
+    """..."""
+    testdir.makepyfile(
+        """
+        import pytest
+        import random
+
+        def get_random_number():
+            return random.randint(0, 1)
+
+        @pytest.fixture(autouse=True, scope="session")
+        def randint_mock(session_mocker):
+            return session_mocker.patch("random.randint", lambda x, y: 5)
+
+        def test_get_random_number():
+            assert get_random_number() == 5
+    """
+    )
+    result = testdir.runpytest_subprocess()
+    assert "AssertionError" not in result.stderr.str()
+    result.stdout.fnmatch_lines("* 1 passed in *")


### PR DESCRIPTION
While the feature proposed in pytest-dev/pytest#1681 is interesting and would serve as a base for a more elegant solution to #136, adding those supplementary mockers allows this plugin to be used in other scopes.

Fix #136