### PR TITLE
Do not mark wheel as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
This pull-request removes marking ``pytest-mock`` wheel as universal because Python2 is no longer supported since version 3.0.0.

Fixes #186 