### PR TITLE
Revert "Do not mark wheel as universal"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Reverts pytest-dev/pytest-mock#187

the package already has a valid python_requires:

https://github.com/pytest-dev/pytest-mock/blob/master/setup.py#L11
I think removing the py2 tag from the wheel will cause pip on py2 to download the sdist before seeing the python_requires