### PR TITLE
Permit warnings in *_stale_pyc tests

### DIFF
--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -809,7 +809,7 @@ def test_abort_patch_context_manager_with_stale_pyc(testdir):
     """
     )
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines("* 1 passed *")
+    result.stdout.fnmatch_lines("* 1 passed*")
 
     kwargs = {"legacy": True}
     assert compileall.compile_file(str(py_fn), **kwargs)
@@ -819,7 +819,7 @@ def test_abort_patch_context_manager_with_stale_pyc(testdir):
 
     py_fn.remove()
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines("* 1 passed *")
+    result.stdout.fnmatch_lines("* 1 passed*")
 
 
 def test_used_with_class_scope(testdir):

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -809,7 +809,7 @@ def test_abort_patch_context_manager_with_stale_pyc(testdir):
     """
     )
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines("* 1 passed*")
+    result.assert_outcomes(passed=1)
 
     kwargs = {"legacy": True}
     assert compileall.compile_file(str(py_fn), **kwargs)
@@ -819,7 +819,7 @@ def test_abort_patch_context_manager_with_stale_pyc(testdir):
 
     py_fn.remove()
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines("* 1 passed*")
+    result.assert_outcomes(passed=1)
 
 
 def test_used_with_class_scope(testdir):


### PR DESCRIPTION
The *_stale_pyc test is repeatedly failing on production systems
due to additional pytest plugins being installed and triggering
PytestAssertRewriteWarnings.  This causes 'passed *' string not to match
because of the ',' after 'passed'.  Match just 'passed*' instead
to solve this.