### PR TITLE
Fix link to docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ Note that this feature is automatically disabled with the ``--tb=native`` option
 mechanism used to suppress traceback entries from ``mock`` module does not work with that option
 anyway plus it generates confusing messages on Python 3.5 due to exception chaining
 
-.. _advanced assertions: http://pytest.org/latest/assert.html
+.. _advanced assertions: http://docs.pytest.org/en/latest/assert.html
 
 
 Use standalone "mock" package


### PR DESCRIPTION
Current link gives 404 and this seems to be the correct link as per pytest docs.