### PR TITLE
Set a new fixture type

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -349,11 +349,11 @@ def _mocker(pytestconfig: Any) -> Generator[MockerFixture, None, None]:
     result.stopall()
 
 
-mocker = pytest.yield_fixture()(_mocker)  # default scope is function
-class_mocker = pytest.yield_fixture(scope="class")(_mocker)
-module_mocker = pytest.yield_fixture(scope="module")(_mocker)
-package_mocker = pytest.yield_fixture(scope="package")(_mocker)
-session_mocker = pytest.yield_fixture(scope="session")(_mocker)
+mocker = pytest.fixture()(_mocker)  # default scope is function
+class_mocker = pytest.fixture(scope="class")(_mocker)
+module_mocker = pytest.fixture(scope="module")(_mocker)
+package_mocker = pytest.fixture(scope="package")(_mocker)
+session_mocker = pytest.fixture(scope="session")(_mocker)
 
 
 _mock_module_patches = []  # type: List[Any]


### PR DESCRIPTION
This PR replaces the deprecated fixture type `yield_fixture` with `fixture`.
> .. deprecated:: 3.0
Use :py:func:`pytest.fixture` directly instead.

[Link to docstring](https://github.com/pytest-dev/pytest/blob/9c0e0c756a36badb84edc017a803b9b0c4c122da/src/_pytest/fixtures.py#L1326-L1327)