### PR TITLE
🦭 Add seal shortcut to mocker fixture

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+3.4.0 (UNRELEASED)
+------------------
+
+* Add `mock.seal` alias to the `mocker` fixture (`#211`_). Thanks `@coiax`_ for the PR.
+
+.. _@coiax: https://github.com/coiax
+.. _#211: https://github.com/pytest-dev/pytest-mock/pull/211
+
 3.3.1 (2020-08-24)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Also, as a convenience, these names from the ``mock`` module are accessible dire
 * `call <https://docs.python.org/3/library/unittest.mock.html#call>`_ *(Version 1.1)*
 * `sentinel <https://docs.python.org/3/library/unittest.mock.html#sentinel>`_ *(Version 1.2)*
 * `mock_open <https://docs.python.org/3/library/unittest.mock.html#mock-open>`_
-* `seal <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.seal>`_ *(Version ???)*
+* `seal <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.seal>`_ *(Version 3.4)*
 
 It is also possible to use mocking functionality from fixtures of other scopes using
 the appropriate mock fixture:

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Also, as a convenience, these names from the ``mock`` module are accessible dire
 * `call <https://docs.python.org/3/library/unittest.mock.html#call>`_ *(Version 1.1)*
 * `sentinel <https://docs.python.org/3/library/unittest.mock.html#sentinel>`_ *(Version 1.2)*
 * `mock_open <https://docs.python.org/3/library/unittest.mock.html#mock-open>`_
+* `seal <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.seal>`_ *(Version ???)*
 
 It is also possible to use mocking functionality from fixtures of other scopes using
 the appropriate mock fixture:

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -65,6 +65,8 @@ class MockerFixture:
         self.create_autospec = mock_module.create_autospec
         self.sentinel = mock_module.sentinel
         self.mock_open = mock_module.mock_open
+        if hasattr(mock_module, "seal"):
+            self.seal = mock_module.seal
 
     def resetall(self) -> None:
         """Call reset_mock() on all patchers started by this fixture."""

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -152,6 +152,12 @@ def test_mock_patch_dict_resetall(mocker: MockerFixture) -> None:
         "NonCallableMock",
         "PropertyMock",
         "sentinel",
+        pytest.param(
+            "seal",
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 7), reason="seal is present on 3.7 and above"
+            ),
+        ),
     ],
 )
 def test_mocker_aliases(name: str, pytestconfig: Any) -> None:


### PR DESCRIPTION
Adds the `seal` function to the mocker fixture, taken directly from the
`mock` module. Since `seal` was only added in Python 3.7, it is not
always present, just like AsyncMock.