### PR TITLE
Add resetall() arguments

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -68,8 +68,13 @@ class MockerFixture:
         if hasattr(mock_module, "seal"):
             self.seal = mock_module.seal
 
-    def resetall(self) -> None:
-        """Call reset_mock() on all patchers started by this fixture."""
+    def resetall(self, *, return_value: bool = False, side_effect: bool = False) -> None:
+        """
+        Call reset_mock() on all patchers started by this fixture.
+        
+        :param bool return_value: Reset the return_value of mocks.
+        :param bool side_effect: Reset the side_effect of mocks.
+        """
         for m in self._mocks:
             m.reset_mock()
 

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -76,7 +76,7 @@ class MockerFixture:
         :param bool side_effect: Reset the side_effect of mocks.
         """
         for m in self._mocks:
-            m.reset_mock()
+            m.reset_mock(return_value=return_value, side_effect=side_effect)
 
     def stopall(self) -> None:
         """

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -183,11 +183,11 @@ def test_mocker_resetall(mocker: MockerFixture) -> None:
     assert not listdir.called
     assert not open.called
     assert listdir.return_value == "foo"
-    assert open.side_effect == ["bar", "baz"]
+    assert list(open.side_effect) == ["baz"]
     
     mocker.resetall(return_value=True, side_effect=True)
     
-    assert listdir.return_value is None
+    assert isinstance(listdir.return_value, mocker.Mock)
     assert open.side_effect is None
 
 

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -170,11 +170,11 @@ def test_mocker_aliases(name: str, pytestconfig: Any) -> None:
 
 
 def test_mocker_resetall(mocker: MockerFixture) -> None:
-    listdir = mocker.patch("os.listdir")
-    open = mocker.patch("os.open")
+    listdir = mocker.patch("os.listdir", return_value="foo")
+    open = mocker.patch("os.open", side_effect=["bar", "baz"])
 
-    listdir("/tmp")
-    open("/tmp/foo.txt")
+    assert listdir("/tmp") == "foo"
+    assert open("/tmp/foo.txt") == "bar"
     listdir.assert_called_once_with("/tmp")
     open.assert_called_once_with("/tmp/foo.txt")
 
@@ -182,6 +182,13 @@ def test_mocker_resetall(mocker: MockerFixture) -> None:
 
     assert not listdir.called
     assert not open.called
+    assert listdir.return_value == "foo"
+    assert open.side_effect == ["bar", "baz"]
+    
+    mocker.resetall(return_value=True, side_effect=True)
+    
+    assert listdir.return_value is None
+    assert open.side_effect is None
 
 
 class TestMockerStub:


### PR DESCRIPTION
Adding standard `unittest.reset_mock()`'s arguments to `MockerFixture.resetall()`. It seems like a small fix, please tell me if I'm missing something!

Closes #213