### PR TITLE
Ensure all the exceptions can be spied on

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,20 @@
 
 * Add `mock.seal` alias to the `mocker` fixture (`#211`_). Thanks `@coiax`_ for the PR.
 
+* Fixed spying on exceptions not covered by the ``Exception``
+  superclass (`#215`_), like ``KeyboardInterrupt`` -- PR `#216`_
+  by `@webknjaz`_.
+
+  Before the fix, both ``spy_return`` and ``spy_exception``
+  whenever such an exception happened. And after this fix,
+  ``spy_exception`` is set to a correct value of an exception
+  that has actually happened.
+
 .. _@coiax: https://github.com/coiax
+.. _@webknjaz: https://github.com/sponsors/webknjaz
 .. _#211: https://github.com/pytest-dev/pytest-mock/pull/211
+.. _#215: https://github.com/pytest-dev/pytest-mock/pull/215
+.. _#216: https://github.com/pytest-dev/pytest-mock/pull/216
 
 3.3.1 (2020-08-24)
 ------------------

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -114,7 +114,7 @@ class MockerFixture:
             spy_obj.spy_exception = None
             try:
                 r = method(*args, **kwargs)
-            except Exception as e:
+            except BaseException as e:
                 spy_obj.spy_exception = e
                 raise
             else:
@@ -126,7 +126,7 @@ class MockerFixture:
             spy_obj.spy_exception = None
             try:
                 r = await method(*args, **kwargs)
-            except Exception as e:
+            except BaseException as e:
                 spy_obj.spy_exception = e
                 raise
             else:


### PR DESCRIPTION
This change replaces `Exception` with `BaseException` in the `spy()`
method provided by the `mocker` fixture. This enables the caller to
spy on things like `KeyboardInterrupt`, `GeneratorExit` and
`SystemExit` exceptions that hasn't been possible before because of
a bug.

Before this change, any occurances of the above exceptions caused
`spy()` to assign `None` to both `spy_return` and `spy_exception`
attributes.

Fixes #215