### PR TITLE
Warn instead of raising exception in context manager

### DIFF
--- a/src/pytest_mock/__init__.py
+++ b/src/pytest_mock/__init__.py
@@ -5,6 +5,7 @@ MockFixture = MockerFixture  # backward-compatibility only (#204)
 __all__ = [
     "MockerFixture",
     "MockFixture",
+    "PytestMockWarning",
     "pytest_addoption",
     "pytest_configure",
     "session_mocker",

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -234,14 +234,14 @@ class MockerFixture:
 
         def context_manager(
             self,
-            target: object,
+            target: builtins.object,
             attribute: str,
-            new: object = DEFAULT,
-            spec: Optional[object] = None,
+            new: builtins.object = DEFAULT,
+            spec: Optional[builtins.object] = None,
             create: bool = False,
-            spec_set: Optional[object] = None,
-            autospec: Optional[object] = None,
-            new_callable: object = None,
+            spec_set: Optional[builtins.object] = None,
+            autospec: Optional[builtins.object] = None,
+            new_callable: builtins.object = None,
             **kwargs: Any
         ) -> unittest.mock.MagicMock:
             """This is equivalent to mock.patch.object except that the returned mock

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -13,6 +13,7 @@ from typing import Union
 import asyncio
 import functools
 import inspect
+import warnings
 
 import pytest
 
@@ -37,6 +38,10 @@ def _get_mock_module(config):
             _get_mock_module._module = unittest.mock
 
     return _get_mock_module._module
+
+
+class PytestMockWarning(UserWarning):
+    """Base class for all warnings emitted by pytest-mock."""
 
 
 class MockerFixture:
@@ -183,9 +188,11 @@ class MockerFixture:
                 # check if `mocked` is actually a mock object, as depending on autospec or target
                 # parameters `mocked` can be anything
                 if hasattr(mocked, "__enter__"):
-                    mocked.__enter__.side_effect = ValueError(
+                    mocked.__enter__.side_effect = lambda: warnings.warn(
                         "Using mocker in a with context is not supported. "
-                        "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager"
+                        "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager",
+                        PytestMockWarning,
+                        stacklevel=4,
                     )
             return mocked
 

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -14,6 +14,7 @@ import asyncio
 import functools
 import inspect
 import warnings
+import sys
 
 import pytest
 
@@ -188,11 +189,15 @@ class MockerFixture:
                 # check if `mocked` is actually a mock object, as depending on autospec or target
                 # parameters `mocked` can be anything
                 if hasattr(mocked, "__enter__"):
+                    if sys.version_info >= (3, 8):
+                        depth = 5
+                    else:
+                        depth = 4
                     mocked.__enter__.side_effect = lambda: warnings.warn(
                         "Using mocker in a with context is not supported. "
                         "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager",
                         PytestMockWarning,
-                        stacklevel=4,
+                        stacklevel=depth,
                     )
             return mocked
 

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -194,7 +194,9 @@ class MockerFixture:
                     else:
                         depth = 4
                     mocked.__enter__.side_effect = lambda: warnings.warn(
-                        "Using mocker in a with context is not supported. "
+                        "Mocks returned by pytest-mock do not need to be used as context managers. "
+                        "The mocker fixture automatically undoes mocking at the end of a test. "
+                        "This warning can be ignored if it was triggered by mocking a context manager. "
                         "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager",
                         PytestMockWarning,
                         stacklevel=depth,

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -815,7 +815,9 @@ def test_warn_patch_object_context_manager(mocker: MockerFixture) -> None:
     a = A()
 
     expected_warning_msg = (
-        "Using mocker in a with context is not supported. "
+        "Mocks returned by pytest-mock do not need to be used as context managers. "
+        "The mocker fixture automatically undoes mocking at the end of a test. "
+        "This warning can be ignored if it was triggered by mocking a context manager. "
         "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager"
     )
 
@@ -830,7 +832,9 @@ def test_warn_patch_object_context_manager(mocker: MockerFixture) -> None:
 
 def test_warn_patch_context_manager(mocker: MockerFixture) -> None:
     expected_warning_msg = (
-        "Using mocker in a with context is not supported. "
+        "Mocks returned by pytest-mock do not need to be used as context managers. "
+        "The mocker fixture automatically undoes mocking at the end of a test. "
+        "This warning can be ignored if it was triggered by mocking a context manager. "
         "https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager"
     )
 

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -867,6 +867,23 @@ def test_context_manager_patch_example(mocker: MockerFixture) -> None:
     assert isinstance(my_func(), mocker.MagicMock)
 
 
+def test_patch_context_manager_with_context_manager(mocker: MockerFixture) -> None:
+    """Test that no warnings are issued when an object patched with
+    patch.context_manager is used as a context manager (#221)"""
+
+    class A:
+        def doIt(self):
+            return False
+
+    a = A()
+
+    with pytest.warns(None) as warn_record:
+        with mocker.patch.context_manager(a, "doIt", return_value=True):
+            assert a.doIt() is True
+
+    assert len(warn_record) == 0
+
+
 def test_abort_patch_context_manager_with_stale_pyc(testdir: Any) -> None:
     """Ensure we don't trigger an error in case the frame where mocker.patch is being
     used doesn't have a 'context' (#169)"""


### PR DESCRIPTION
Instead of raising an exception, warn when a pytest-mock mock is used as
a context manager. This lets pytest-mock mock objects that are used as
context managers, like threading.Lock, while still letting users know
that mocks returned from pytest-mock do not need their __enter__ method
called to take effect.

Create a PytestMockWarning class so that the warning is easy to
pinpoint and handle.

#192 