### PR TITLE
use getattr_static in spy instead of __getattributes__

### DIFF
--- a/src/pytest_mock/_util.py
+++ b/src/pytest_mock/_util.py
@@ -1,0 +1,36 @@
+from typing import Union, Any
+
+_mock_module: Any = None
+
+
+def get_mock_module(config):
+    """
+    Import and return the actual "mock" module. By default this is
+    "unittest.mock", but the user can force to always use "mock" using
+    the mock_use_standalone_module ini option.
+    """
+    global _mock_module
+    if _mock_module is None:
+        use_standalone_module = parse_ini_boolean(
+            config.getini("mock_use_standalone_module")
+        )
+        if use_standalone_module:
+            import mock
+
+            _mock_module = mock
+        else:
+            import unittest.mock
+
+            _mock_module = unittest.mock
+
+    return _mock_module
+
+
+def parse_ini_boolean(value: Union[bool, str]) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+    raise ValueError("unknown string for bool: %r" % value)

--- a/src/pytest_mock/_util.py
+++ b/src/pytest_mock/_util.py
@@ -1,6 +1,6 @@
-from typing import Union, Any
+from typing import Union
 
-_mock_module: Any = None
+_mock_module = None
 
 
 def get_mock_module(config):

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -7,7 +7,7 @@ from typing import Callable, Any, Tuple, Generator, Type
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture, PytestMockWarning
+from pytest_mock import MockerFixture, PytestMockWarning  # type: ignore
 
 pytest_plugins = "pytester"
 
@@ -162,7 +162,7 @@ def test_mock_patch_dict_resetall(mocker: MockerFixture) -> None:
     ],
 )
 def test_mocker_aliases(name: str, pytestconfig: Any) -> None:
-    from pytest_mock.plugin import _get_mock_module
+    from pytest_mock.plugin import _get_mock_module  # type: ignore
 
     mock_module = _get_mock_module(pytestconfig)
 
@@ -268,6 +268,19 @@ def test_instance_method_spy_exception(
         assert str(spy.spy_exception) == "Error with {}".format(v)
 
 
+def test_instance_method_spy_autospec_true(mocker: MockerFixture) -> None:
+    class Foo:
+        def bar(self, arg):
+            return arg * 2
+
+    foo = Foo()
+    spy = mocker.spy(foo, "bar")
+    with pytest.raises(
+        AttributeError, match="'function' object has no attribute 'fake_assert_method'"
+    ):
+        spy.fake_assert_method(arg=5)
+
+
 def test_spy_reset(mocker: MockerFixture) -> None:
     class Foo(object):
         def bar(self, x):
@@ -340,6 +353,17 @@ def test_class_method_spy(mocker: MockerFixture) -> None:
     assert Foo.bar.spy_return == 20  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
+
+
+@skip_pypy
+def test_class_method_spy_autospec_false(mocker: MockerFixture) -> None:
+    class Foo:
+        @classmethod
+        def bar(cls, arg):
+            return arg * 2
+
+    spy = mocker.spy(Foo, "bar")
+    spy.fake_assert_method()
 
 
 @skip_pypy

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -7,7 +7,7 @@ from typing import Callable, Any, Tuple, Generator, Type
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture, PytestMockWarning  # type: ignore
+from pytest_mock import MockerFixture, PytestMockWarning
 
 pytest_plugins = "pytester"
 
@@ -162,9 +162,9 @@ def test_mock_patch_dict_resetall(mocker: MockerFixture) -> None:
     ],
 )
 def test_mocker_aliases(name: str, pytestconfig: Any) -> None:
-    from pytest_mock.plugin import _get_mock_module  # type: ignore
+    from pytest_mock._util import get_mock_module
 
-    mock_module = _get_mock_module(pytestconfig)
+    mock_module = get_mock_module(pytestconfig)
 
     mocker = MockerFixture(pytestconfig)
     assert getattr(mocker, name) is getattr(mock_module, name)


### PR DESCRIPTION
When attempting to use `mocker.spy` on a Stripe class in my project, I ran into this error:

```python
    def test_create_customer(self, mocker):
>       stripe_spy = mocker.spy(stripe.Customer, 'create')

tests/[...]/test_stripe_customer_service.py:16:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pytest_mock.plugin.MockerFixture object at 0x10d6ebdd0>, obj = <class 'stripe.api_resources.customer.Customer'>, name = 'create'

    def spy(self, obj: object, name: str) -> unittest.mock.MagicMock:
        """
        Create a spy of method. It will run method normally, but it is now
        possible to use `mock` call features with it, like call count.

        :param obj: An object.
        :param name: A method in object.
        :return: Spy object.
        """
        method = getattr(obj, name)

        autospec = inspect.ismethod(method) or inspect.isfunction(method)
        # Can't use autospec classmethod or staticmethod objects
        # see: https://bugs.python.org/issue23078
        if inspect.isclass(obj):
            # Bypass class descriptor:
            # http://stackoverflow.com/questions/14187973/python3-check-if-method-is-static
            try:
>               value = obj.__getattribute__(obj, name)  # type:ignore
E               TypeError: descriptor '__getattribute__' requires a 'dict' object but received a 'type'

venv/lib/python3.7/site-packages/pytest_mock/plugin.py:110: TypeError
```

[Here is the Customer source code for reference](https://github.com/stripe/stripe-python/blob/master/stripe/api_resources/customer.py), a class inheriting from multiple parent classes and including some custom method wrappers.

While digging in order to fix this, I ended up at [the stackoverflow question linked to in the original code](https://stackoverflow.com/questions/14187973/python3-check-if-method-is-static) which mentioned the `inspect` module's method `getattr_static` available as of 3.2. This will accomplish the same behaviour as before, as well as work for a larger variety of classes.

I also checked up on the bug that this workaround is there for in the first place, and it was fixed in 3.7 it seems, so eventually autospec can be true by default in theory.

I don't quite know how to reproduce the exact kind of class that would have caused this error in the first place, open to suggestions in order to add a test for it.

