### PR TITLE
Correct type annotations in patch.dict()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+3.5.2 (UNRELEASED)
+------------------
+
+* Correct type annotations for ``mocker.patch.object`` to also include the string form.
+  Thanks `@plannigan`_ for the PR (`#235`_).
+
+.. _@plannigan: https://github.com/plannigan
+.. _#235: https://github.com/pytest-dev/pytest-mock/pull/235
+
 3.5.1 (2021-01-10)
 ------------------
 

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -267,7 +267,7 @@ class MockerFixture:
 
         def dict(
             self,
-            in_dict: Mapping[Any, Any],
+            in_dict: Union[Mapping[Any, Any], str],
             values: Union[Mapping[Any, Any], Iterable[Tuple[Any, Any]]] = (),
             clear: bool = False,
             **kwargs: Any


### PR DESCRIPTION
[The documentation for `patch.dict()`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch.dict) says:
> `in_dict` can be a dictionary or a mapping like container. If it is a mapping then it must at least support getting, setting and deleting items plus iterating over keys.
> `in_dict` can also be a string specifying the name of the dictionary, which will then be fetched by importing it.

However, the argument is currently annotation is `Mapping[Any, Any]`. This updates the annotation to also include the string option.