### PR TITLE
modify resetall to work with patch object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+3.6.1 (UNRELEASED)
+------------------
+
+* Fix ``mocker.resetall()`` when using ``mocker.spy()`` (`#237`_). Thanks `@blaxter`_ for the report and `@shadycuz`_ for the PR.
+
+.. _@blaxter: https://github.com/blaxter
+.. _@shadycuz: https://github.com/shadycuz
+.. _#237: https://github.com/pytest-dev/pytest-mock/issues/237
+
 3.6.0 (2021-04-24)
 ------------------
 

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -16,6 +16,7 @@ from typing import Mapping
 from typing import Optional
 from typing import overload
 from typing import Tuple
+from typing import Type
 from typing import TypeVar
 from typing import Union
 
@@ -69,13 +70,18 @@ class MockerFixture:
         :param bool return_value: Reset the return_value of mocks.
         :param bool side_effect: Reset the side_effect of mocks.
         """
+        supports_reset_mock_with_args: Tuple[Type[Any], ...]
+        if hasattr(self, "AsyncMock"):
+            supports_reset_mock_with_args = (self.Mock, self.AsyncMock)
+        else:
+            supports_reset_mock_with_args = (self.Mock,)
+
         for m in self._mocks:
-
-            if isinstance(m, self.Mock):
+            # See issue #237.
+            if isinstance(m, supports_reset_mock_with_args):
                 m.reset_mock(return_value=return_value, side_effect=side_effect)
-                continue
-
-            m.reset_mock()
+            else:
+                m.reset_mock()
 
     def stopall(self) -> None:
         """

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -70,7 +70,12 @@ class MockerFixture:
         :param bool side_effect: Reset the side_effect of mocks.
         """
         for m in self._mocks:
-            m.reset_mock(return_value=return_value, side_effect=side_effect)
+
+            if isinstance(m, self.Mock):
+                m.reset_mock(return_value=return_value, side_effect=side_effect)
+                continue
+
+            m.reset_mock()
 
     def stopall(self) -> None:
         """

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -310,7 +310,7 @@ def test_spy_reset(mocker: MockerFixture) -> None:
     assert spy.spy_return == 30
     assert spy.spy_exception is None
 
-    # Testing spy can still be reset.
+    # Testing spy can still be reset (#237).
     mocker.resetall()
 
     with pytest.raises(ValueError):

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -310,6 +310,9 @@ def test_spy_reset(mocker: MockerFixture) -> None:
     assert spy.spy_return == 30
     assert spy.spy_exception is None
 
+    # Testing spy can still be reset.
+    mocker.resetall()
+
     with pytest.raises(ValueError):
         Foo().bar(0)
     assert spy.spy_return is None


### PR DESCRIPTION
Fixes #237

It seems `spy` and `patch.object` have a `reset_mock` that doesn't take the `return_value` and `side_effect` keyword args.

I originally tried to fix this in `_start_patch`
https://github.com/pytest-dev/pytest-mock/blob/c3878181c9ed65d748694e0f4b1eb58bef3dfce5/src/pytest_mock/plugin.py#L171-L178

but changing `self._mocks.append(mocked) ` to only append actually `Mock` objects breaks my repo worse because then I lose the ability to call `resetall` on patched objects.

This seemed like the best approach to take. 

I also tried to get this to fail in a test case but could not get the error to trigger. I suspect the issue might be with the version of `mock` or `unittest.mock` that our projects are using. I should be on the lastest of everything, but I'm still facing the error which is strange 🤔 

Here is my repo https://github.com/DontShaveTheYak/cloud-radar/pull/32 if you want to try and debug it. 