### PR TITLE
Improve test_standalone_mock

### DIFF
--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -707,10 +707,14 @@ def test_monkeypatch_no_terminal(testdir: Any) -> None:
 
 def test_standalone_mock(testdir: Any) -> None:
     """Check that the "mock_use_standalone" is being used."""
+    pytest.importorskip("mock")
+
     testdir.makepyfile(
         """
+        import mock
+
         def test_foo(mocker):
-            pass
+            assert mock.MagicMock is mocker.MagicMock
     """
     )
     testdir.makeini(
@@ -720,8 +724,7 @@ def test_standalone_mock(testdir: Any) -> None:
     """
     )
     result = testdir.runpytest_subprocess()
-    assert result.ret == 3
-    result.stderr.fnmatch_lines(["*No module named 'mock'*"])
+    assert result.ret == 0
 
 
 @pytest.mark.usefixtures("needs_assert_rewrite")

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist = py{37,38,39,310}, norewrite
 passenv = USER USERNAME
 deps =
     coverage
+    mock
     pytest-asyncio
 commands =
     coverage run --append --source={envsitepackagesdir}/pytest_mock -m pytest tests


### PR DESCRIPTION
This actually tests that the 'mock' module is being used when use_standalone_mock is true.

It also skips the test if 'mock' is not installed.

Close #276