### PR TITLE
Remove unnecessary import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from io import open
-
 from setuptools import find_packages
 from setuptools import setup
 


### PR DESCRIPTION
This import was useful for Python 2 but is no longer needed in Python 3.
* https://github.com/asottile/pyupgrade#open-alias