### PR TITLE
Add docs/_static directory to allow sphinx-build to work cleanly

### DIFF
--- a/docs/_static/.gitignore
+++ b/docs/_static/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
The `sphinx-build` command expects to find a `docs/_static` directory, as specified in `docs/conf.py`.  This patch creates an essentially-empty directory for this purpose.  (I learnt this trick from https://github.com/chrislit/abydos)