### PR TITLE
Fix gen-release-notes script

### DIFF
--- a/scripts/gen-release-notes.py
+++ b/scripts/gen-release-notes.py
@@ -20,6 +20,11 @@ output_lines = []
 first_heading_found = False
 for line in md_text.splitlines():
     if line.startswith("# "):
+        # Skip the first section (normally # Releases).
+        pass
+    elif line.startswith("## "):
+        # First second-level section, note it and skip the text,
+        # as we are only interested in the individual release items.
         if first_heading_found:
             break
         first_heading_found = True


### PR DESCRIPTION
Since we moved to readthedocs, the section headers changed so this script needs to be updated.