### PR TITLE
Remove old tox env (linting) from contributing doc

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -15,7 +15,7 @@ Tests are run with ``tox``, you can run the baseline environments before submitt
 
 .. code-block:: console
 
-    $ tox -e py38,linting
+    $ tox -e py38
 
 Style checks and formatting are done automatically during commit courtesy of
 `pre-commit <https://pre-commit.com>`_.


### PR DESCRIPTION
Since `linting` tox env is deleted in 3c6b070, running `tox -e py3,linting` would just run unit tests twice.