### PR TITLE
Add support for `resetall` to `create_autospec`

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -66,11 +66,19 @@ class MockerFixture:
         self.call = mock_module.call
         self.ANY = mock_module.ANY
         self.DEFAULT = mock_module.DEFAULT
-        self.create_autospec = mock_module.create_autospec
         self.sentinel = mock_module.sentinel
         self.mock_open = mock_module.mock_open
         if hasattr(mock_module, "seal"):
             self.seal = mock_module.seal
+
+    def create_autospec(
+        self, spec: Any, spec_set: bool = False, instance: bool = False, **kwargs: Any
+    ) -> MockType:
+        m: MockType = self.mock_module.create_autospec(
+            spec, spec_set, instance, **kwargs
+        )
+        self._patches_and_mocks.append((None, m))
+        return m
 
     def resetall(
         self, *, return_value: bool = False, side_effect: bool = False
@@ -102,7 +110,8 @@ class MockerFixture:
         times.
         """
         for p, m in reversed(self._patches_and_mocks):
-            p.stop()
+            if p:
+                p.stop()
         self._patches_and_mocks.clear()
 
     def stop(self, mock: unittest.mock.MagicMock) -> None:

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -60,6 +60,14 @@ class UnixFS:
         return os.listdir(path)
 
 
+class TestObject:
+    """
+    Class that is used for testing create_autospec with child mocks
+    """
+    def run(self) -> str:
+        return "not mocked"
+
+
 @pytest.fixture
 def check_unix_fs_mocked(
     tmpdir: Any, mocker: MockerFixture
@@ -185,22 +193,34 @@ def test_mocker_resetall(mocker: MockerFixture) -> None:
     listdir = mocker.patch("os.listdir", return_value="foo")
     open = mocker.patch("os.open", side_effect=["bar", "baz"])
 
+    mocked_object = mocker.create_autospec(TestObject)
+    mocked_object.run.return_value = "mocked"
+
     assert listdir("/tmp") == "foo"
     assert open("/tmp/foo.txt") == "bar"
+    assert mocked_object.run() == "mocked"
     listdir.assert_called_once_with("/tmp")
     open.assert_called_once_with("/tmp/foo.txt")
+    mocked_object.run.assert_called_once()
 
     mocker.resetall()
 
     assert not listdir.called
     assert not open.called
+    assert not mocked_object.called
     assert listdir.return_value == "foo"
     assert list(open.side_effect) == ["baz"]
+    assert mocked_object.run.return_value == "mocked"
 
     mocker.resetall(return_value=True, side_effect=True)
 
     assert isinstance(listdir.return_value, mocker.Mock)
     assert open.side_effect is None
+
+    if sys.version_info >= (3, 9):
+        # The reset on child mocks have been implemented in 3.9
+        # https://bugs.python.org/issue38932
+        assert mocked_object.run.return_value != "mocked"
 
 
 class TestMockerStub:


### PR DESCRIPTION
This PR adds support for `resetall` to `create_autospec`.

1. I have added a new `create_autospec` function to the `MockerFixture`, that wraps original `create_autospec` and adds a reference to the `_patches_and_mocks` list, so it could be reset by `resetall`.

2. `stopall` had to be modified in order to ignore `None` patcher, maybe there's a better way to do this instead.

3. Added new test cases to `test_mocker_resetall` test
4. `test_mocker_aliases` is failing - maybe we don't need to test it for `create_autospec` anymore, since we have it tested in `test_mocker_resetall`?