### PR TITLE
Ship py.typed with the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.typed


### PR DESCRIPTION
Without this, I was hitting mypy errors that there were no stub found for pytest-mock, as I had not installed the wheel.

See
https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages for mypy documentation which describes this.