### PR TITLE
autospec for spy: remove if else which was in place for python < 3.7

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -137,14 +137,6 @@ class MockerFixture:
         :return: Spy object.
         """
         method = getattr(obj, name)
-        if inspect.isclass(obj) and isinstance(
-            inspect.getattr_static(obj, name), (classmethod, staticmethod)
-        ):
-            # Can't use autospec classmethod or staticmethod objects before 3.7
-            # see: https://bugs.python.org/issue23078
-            autospec = False
-        else:
-            autospec = inspect.ismethod(method) or inspect.isfunction(method)
 
         def wrapper(*args, **kwargs):
             spy_obj.spy_return = None
@@ -174,6 +166,8 @@ class MockerFixture:
             wrapped = functools.update_wrapper(async_wrapper, method)
         else:
             wrapped = functools.update_wrapper(wrapper, method)
+
+        autospec = inspect.ismethod(method) or inspect.isfunction(method)
 
         spy_obj = self.patch.object(obj, name, side_effect=wrapped, autospec=autospec)
         spy_obj.spy_return = None

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -342,7 +342,7 @@ def test_instance_class_static_method_spy_autospec_true(mocker: MockerFixture) -
 
     static_method_spy = mocker.spy(Foo, "qux")
     with pytest.raises(
-            AttributeError, match="Mock object has no attribute 'fake_assert_method'"
+        AttributeError, match="Mock object has no attribute 'fake_assert_method'"
     ):
         static_method_spy.fake_assert_method(arg=5)
 

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -314,17 +314,37 @@ def test_instance_method_spy_exception(
         assert str(spy.spy_exception) == f"Error with {v}"
 
 
-def test_instance_method_spy_autospec_true(mocker: MockerFixture) -> None:
+def test_instance_class_static_method_spy_autospec_true(mocker: MockerFixture) -> None:
     class Foo:
         def bar(self, arg):
             return arg * 2
 
+        @classmethod
+        def baz(cls, arg):
+            return arg * 2
+
+        @staticmethod
+        def qux(arg):
+            return arg * 2
+
     foo = Foo()
-    spy = mocker.spy(foo, "bar")
+    instance_method_spy = mocker.spy(foo, "bar")
     with pytest.raises(
         AttributeError, match="'function' object has no attribute 'fake_assert_method'"
     ):
-        spy.fake_assert_method(arg=5)
+        instance_method_spy.fake_assert_method(arg=5)
+
+    class_method_spy = mocker.spy(Foo, "baz")
+    with pytest.raises(
+        AttributeError, match="Mock object has no attribute 'fake_assert_method'"
+    ):
+        class_method_spy.fake_assert_method(arg=5)
+
+    static_method_spy = mocker.spy(Foo, "qux")
+    with pytest.raises(
+            AttributeError, match="Mock object has no attribute 'fake_assert_method'"
+    ):
+        static_method_spy.fake_assert_method(arg=5)
 
 
 def test_spy_reset(mocker: MockerFixture) -> None:
@@ -402,17 +422,6 @@ def test_class_method_spy(mocker: MockerFixture) -> None:
     assert Foo.bar.spy_return == 20  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
-
-
-@skip_pypy
-def test_class_method_spy_autospec_false(mocker: MockerFixture) -> None:
-    class Foo:
-        @classmethod
-        def bar(cls, arg):
-            return arg * 2
-
-    spy = mocker.spy(Foo, "bar")
-    spy.fake_assert_method()
 
 
 @skip_pypy


### PR DESCRIPTION
I made this PR in the past #224 which worked on an `if/else` for the `spy` feature to get around a bug in python that was fixed in 3.7. Now that this library supports only >= 3.8 this check is no longer needed.

I suppose this would be "breaking changes" for anyone who may be incorrectly calling methods on class/static method spies?