### PR TITLE
Require pytest >=6.2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         tox_env: ["py"]
         include:
+          - python: "3.10"
+            os: ubuntu-latest
+            tox_env: "pytest6"
           - python: "3.12"
             os: ubuntu-latest
             tox_env: "norewrite"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+UNRELEASED
+----------
+
+* ``pytest-mock`` now requires ``pytest>=6.2.5``.
+
 3.12.0 (2023-10-19)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "pytest_mock": ["py.typed"],
     },
     python_requires=">=3.8",
-    install_requires=["pytest>=5.0"],
+    install_requires=["pytest>=6.2.5"],
     use_scm_version={"write_to": "src/pytest_mock/_version.py"},
     setup_requires=["setuptools_scm"],
     url="https://github.com/pytest-dev/pytest-mock/",

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -559,7 +559,7 @@ def assert_argument_introspection(left: Any, right: Any) -> Generator[None, None
         # NOTE: we assert with either verbose or not, depending on how our own
         #       test was run by examining sys.argv
         verbose = any(a.startswith("-v") for a in sys.argv)
-        if int(pytest.version_tuple[0]) < 8:
+        if int(pytest.__version__.split(".")[0]) < 8:
             expected = "\n  ".join(util._compare_eq_iterable(left, right, verbose))  # type:ignore[arg-type]
         else:
             expected = "\n  ".join(
@@ -888,12 +888,12 @@ def test_detailed_introspection(testdir: Any) -> None:
         "*Args:",
         "*assert ('fo',) == ('',)",
         "*At index 0 diff: 'fo' != ''*",
-        "*Use -v to get more diff*",
+        "*Use -v to*",
         "*Kwargs:*",
         "*assert {} == {'bar': 4}*",
         "*Right contains* more item*",
         "*{'bar': 4}*",
-        "*Use -v to get more diff*",
+        "*Use -v to*",
     ]
     result.stdout.fnmatch_lines(expected_lines)
 
@@ -929,12 +929,12 @@ def test_detailed_introspection_async(testdir: Any) -> None:
         "*Args:",
         "*assert ('fo',) == ('',)",
         "*At index 0 diff: 'fo' != ''*",
-        "*Use -v to get more diff*",
+        "*Use -v to*",
         "*Kwargs:*",
         "*assert {} == {'bar': 4}*",
         "*Right contains* more item*",
         "*{'bar': 4}*",
-        "*Use -v to get more diff*",
+        "*Use -v to*",
     ]
     result.stdout.fnmatch_lines(expected_lines)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 minversion = 3.5.3
-envlist = py{38,39,310,311,312}, norewrite
+envlist = py{38,39,310,311,312}, norewrite, pytest6
 
 [testenv]
 deps =
     coverage
     mock
     pytest-asyncio
+    pytest6: pytest==6.2.5
 commands =
     coverage run --append --source={envsitepackagesdir}/pytest_mock -m pytest tests --color=yes
 


### PR DESCRIPTION
Also add a tox environment testing in that specific version to ensure compatibility with 6.2.5.