### PR TITLE
Fix ruff isort configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,5 @@
 exclude: '^($|.*\.bin)'
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
   - repo: local
     hooks:
       - id: rst
@@ -17,7 +12,7 @@ repos:
     rev: v0.1.14
     hooks:
       - id: ruff
-        args: [ --fix ]
+        args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.ruff]
+[tool.ruff.lint]
+extend-select = ["I001"]
+
+[tool.ruff.lint.isort]
+force-single-line = true
+known-third-party = ["src"]

--- a/src/pytest_mock/__init__.py
+++ b/src/pytest_mock/__init__.py
@@ -1,11 +1,11 @@
+from pytest_mock.plugin import MockerFixture
+from pytest_mock.plugin import PytestMockWarning
 from pytest_mock.plugin import class_mocker
 from pytest_mock.plugin import mocker
-from pytest_mock.plugin import MockerFixture
 from pytest_mock.plugin import module_mocker
 from pytest_mock.plugin import package_mocker
 from pytest_mock.plugin import pytest_addoption
 from pytest_mock.plugin import pytest_configure
-from pytest_mock.plugin import PytestMockWarning
 from pytest_mock.plugin import session_mocker
 
 MockFixture = MockerFixture  # backward-compatibility only (#204)

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -7,18 +7,18 @@ import unittest.mock
 import warnings
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Dict
 from typing import Generator
 from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import Optional
-from typing import overload
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
 from typing import Union
+from typing import cast
+from typing import overload
 
 import pytest
 

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -12,7 +12,6 @@ from typing import Type
 from unittest.mock import MagicMock
 
 import pytest
-
 from pytest_mock import MockerFixture
 from pytest_mock import PytestMockWarning
 


### PR DESCRIPTION
In addition, remove other hooks which are not needed now as they are handled by ruff.