### PR TITLE
Attest build provenance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Download Package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Packages
         path: dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,10 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
+    # Required by attest-build-provenance-github.
+    permissions:
+      id-token: write
+      attestations: write
     env:
       SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.version }}
 
@@ -20,6 +24,9 @@ jobs:
 
     - name: Build and Check Package
       uses: hynek/build-and-inspect-python-package@v1.5
+      with:
+        attest-build-provenance-github: 'true'
+
 
   deploy:
     needs: package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build and Check Package
-        uses: hynek/build-and-inspect-python-package@v1.5
+        uses: hynek/build-and-inspect-python-package@v2.5.0
         with:
           attest-build-provenance-github: 'true'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,15 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v3
       - name: Build and Check Package
         uses: hynek/build-and-inspect-python-package@v1.5
+        with:
+          attest-build-provenance-github: 'true'
 
   test:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Download Package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Packages
         path: dist


### PR DESCRIPTION
This uses the new build provenance support added in [build-and-inspect-python-package 2.5.0](https://github.com/hynek/build-and-inspect-python-package/blob/main/CHANGELOG.md#250---2024-05-13).