### PR TITLE
Replace asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -1,4 +1,3 @@
-import asyncio
 import builtins
 import functools
 import inspect
@@ -196,7 +195,7 @@ class MockerFixture:
                 spy_obj.spy_return_list.append(r)
             return r
 
-        if asyncio.iscoroutinefunction(method):
+        if inspect.iscoroutinefunction(method):
             wrapped = functools.update_wrapper(async_wrapper, method)
         else:
             wrapped = functools.update_wrapper(wrapper, method)


### PR DESCRIPTION
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead

Fixes https://github.com/pytest-dev/pytest-mock/issues/468