### PR TITLE
Add `AsyncMock` to list of available modules from `unittest.mock` in documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,6 +29,7 @@ Also, as a convenience, these names from the ``mock`` module are accessible dire
 * `Mock <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock>`_
 * `MagicMock <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.MagicMock>`_
 * `PropertyMock <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock>`_
+* `AsyncMock <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.AsyncMock>`_
 * `ANY <https://docs.python.org/3/library/unittest.mock.html#any>`_
 * `DEFAULT <https://docs.python.org/3/library/unittest.mock.html#default>`_
 * `call <https://docs.python.org/3/library/unittest.mock.html#call>`_


### PR DESCRIPTION
When using `unittest.mock` as the `mock_module`, the `AsyncMock` class has been made accessible directly from the `mocker` fixture since v3.2.0:

https://github.com/pytest-dev/pytest-mock/blob/9b6e10645f6f15b6972391fc4295faa1f658c1c3/src/pytest_mock/plugin.py#L50-L51

I noticed that `AsyncMock` is not included in the list in the documentation so this PR adds it in.
