### PR TITLE
Add asyncio fixture to test_instance_async_method_spy

### DIFF
--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -523,6 +523,7 @@ def test_callable_like_spy(testdir: Any, mocker: MockerFixture) -> None:
     assert spy.spy_return == 20
     assert spy.spy_return_list == [20]
 
+
 @pytest.mark.asyncio
 async def test_instance_async_method_spy(mocker: MockerFixture) -> None:
     class Foo:

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -523,7 +523,7 @@ def test_callable_like_spy(testdir: Any, mocker: MockerFixture) -> None:
     assert spy.spy_return == 20
     assert spy.spy_return_list == [20]
 
-
+@pytest.mark.asyncio
 async def test_instance_async_method_spy(mocker: MockerFixture) -> None:
     class Foo:
         async def bar(self, arg):


### PR DESCRIPTION
This ensures that this test executes and passes
with pytest-8.4+

pytest now throws errors for such functions [1]
which were skipped in older versions

[1] https://github.com/pytest-dev/pytest/issues/11372