### PR TITLE
Change 3.14.1 release date from August to May 26

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Releases
 ========
 
-3.14.1 (2025-08-26)
+3.14.1 (2025-05-26)
 -------------------
 
 * `#503 <https://github.com/pytest-dev/pytest-mock/pull/503>`_: Python 3.14 is now officially supported.


### PR DESCRIPTION
https://pytest-mock.readthedocs.io/en/latest/changelog.html#id1 currently shows "3.14.1 (2025-08-26)". It's only 2025-08-04 now, so that can't be right.
https://pypi.org/project/pytest-mock/#history says May 26, 2025.