### PR TITLE
Add `spy_return_iter` attribute to `spy`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+UNRELEASED
+----------
+
+* `#524 <https://github.com/pytest-dev/pytest-mock/pull/524>`_: Added ``spy_return_iter`` to ``mocker.spy``, which contains a duplicate of the return value of the spied method if it is an ``Iterator``.
+
 3.14.1 (2025-05-26)
 -------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -81,6 +81,7 @@ are available (like ``assert_called_once_with`` or ``call_count`` in the example
 In addition, spy objects contain two extra attributes:
 
 * ``spy_return``: contains the last returned value of the spied function.
+* ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator.
 * ``spy_return_list``: contains a list of all returned values of the spied function (new in ``3.13``).
 * ``spy_exception``: contain the last exception value raised by the spied function/method when
   it was last called, or ``None`` if no exception was raised.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -81,7 +81,7 @@ are available (like ``assert_called_once_with`` or ``call_count`` in the example
 In addition, spy objects contain two extra attributes:
 
 * ``spy_return``: contains the last returned value of the spied function.
-* ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator.
+* ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator. Uses `tee <https://docs.python.org/3/library/itertools.html#itertools.tee>`__) to duplicate the iterator.
 * ``spy_return_list``: contains a list of all returned values of the spied function (new in ``3.13``).
 * ``spy_exception``: contain the last exception value raised by the spied function/method when
   it was last called, or ``None`` if no exception was raised.

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -11,7 +11,6 @@ from typing import Iterable
 from typing import Iterator
 from typing import Tuple
 from typing import Type
-from unittest.mock import ANY
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
@@ -559,7 +558,9 @@ def test_spy_return_iter(mocker: MockerFixture, iterator: Iterator[int]) -> None
     assert spy.spy_return is not None
     assert spy.spy_return_iter is not None
     assert list(spy.spy_return_iter) == result
-    assert spy.spy_return_list == [ANY]
+
+    [return_value] = spy.spy_return_list
+    assert isinstance(return_value, Iterator)
 
 
 @pytest.mark.parametrize("iterable", [(0, 1, 2), [0, 1, 2], range(3)])

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -583,12 +583,12 @@ def test_spy_return_iter_ignore_plain_iterable(
 
 def test_spy_return_iter_resets(mocker: MockerFixture) -> None:
     class Foo:
-        iterables = [
+        iterables: list[Any] = [
             (i for i in range(3)),
             99,
         ]
 
-        def bar(self) -> Iterable[int]:
+        def bar(self) -> Any:
             return self.iterables.pop(0)
 
     foo = Foo()

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -7,8 +7,11 @@ from contextlib import contextmanager
 from typing import Any
 from typing import Callable
 from typing import Generator
+from typing import Iterable
+from typing import Iterator
 from typing import Tuple
 from typing import Type
+from unittest.mock import ANY
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
@@ -265,12 +268,14 @@ def test_instance_method_spy(mocker: MockerFixture) -> None:
     assert other.bar(arg=10) == 20
     foo.bar.assert_called_once_with(arg=10)  # type:ignore[attr-defined]
     assert foo.bar.spy_return == 20  # type:ignore[attr-defined]
+    assert foo.bar.spy_return_iter is None  # type:ignore[attr-defined]
     assert foo.bar.spy_return_list == [20]  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
     assert foo.bar(arg=11) == 22
     assert foo.bar(arg=12) == 24
     assert spy.spy_return == 24
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20, 22, 24]
 
 
@@ -349,11 +354,13 @@ def test_spy_reset(mocker: MockerFixture) -> None:
 
     spy = mocker.spy(Foo, "bar")
     assert spy.spy_return is None
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == []
     assert spy.spy_exception is None
 
     Foo().bar(10)
     assert spy.spy_return == 30
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [30]
     assert spy.spy_exception is None
 
@@ -363,11 +370,13 @@ def test_spy_reset(mocker: MockerFixture) -> None:
     with pytest.raises(ValueError):
         Foo().bar(0)
     assert spy.spy_return is None
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == []
     assert str(spy.spy_exception) == "invalid x"
 
     Foo().bar(15)
     assert spy.spy_return == 45
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [45]
     assert spy.spy_exception is None
 
@@ -404,6 +413,7 @@ def test_instance_method_by_subclass_spy(mocker: MockerFixture) -> None:
     calls = [mocker.call(foo, arg=10), mocker.call(other, arg=10)]
     assert spy.call_args_list == calls
     assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20, 20]
 
 
@@ -418,9 +428,11 @@ def test_class_method_spy(mocker: MockerFixture) -> None:
     assert Foo.bar(arg=10) == 20
     Foo.bar.assert_called_once_with(arg=10)  # type:ignore[attr-defined]
     assert Foo.bar.spy_return == 20  # type:ignore[attr-defined]
+    assert Foo.bar.spy_return_iter is None  # type:ignore[attr-defined]
     assert Foo.bar.spy_return_list == [20]  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20]
 
 
@@ -438,9 +450,11 @@ def test_class_method_subclass_spy(mocker: MockerFixture) -> None:
     assert Foo.bar(arg=10) == 20
     Foo.bar.assert_called_once_with(arg=10)  # type:ignore[attr-defined]
     assert Foo.bar.spy_return == 20  # type:ignore[attr-defined]
+    assert Foo.bar.spy_return_iter is None  # type:ignore[attr-defined]
     assert Foo.bar.spy_return_list == [20]  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20]
 
 
@@ -460,9 +474,11 @@ def test_class_method_with_metaclass_spy(mocker: MockerFixture) -> None:
     assert Foo.bar(arg=10) == 20
     Foo.bar.assert_called_once_with(arg=10)  # type:ignore[attr-defined]
     assert Foo.bar.spy_return == 20  # type:ignore[attr-defined]
+    assert Foo.bar.spy_return_iter is None  # type:ignore[attr-defined]
     assert Foo.bar.spy_return_list == [20]  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20]
 
 
@@ -477,9 +493,11 @@ def test_static_method_spy(mocker: MockerFixture) -> None:
     assert Foo.bar(arg=10) == 20
     Foo.bar.assert_called_once_with(arg=10)  # type:ignore[attr-defined]
     assert Foo.bar.spy_return == 20  # type:ignore[attr-defined]
+    assert Foo.bar.spy_return_iter is None  # type:ignore[attr-defined]
     assert Foo.bar.spy_return_list == [20]  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20]
 
 
@@ -497,9 +515,11 @@ def test_static_method_subclass_spy(mocker: MockerFixture) -> None:
     assert Foo.bar(arg=10) == 20
     Foo.bar.assert_called_once_with(arg=10)  # type:ignore[attr-defined]
     assert Foo.bar.spy_return == 20  # type:ignore[attr-defined]
+    assert Foo.bar.spy_return_iter is None  # type:ignore[attr-defined]
     assert Foo.bar.spy_return_list == [20]  # type:ignore[attr-defined]
     spy.assert_called_once_with(arg=10)
     assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20]
 
 
@@ -521,7 +541,65 @@ def test_callable_like_spy(testdir: Any, mocker: MockerFixture) -> None:
     uut.call_like(10)
     spy.assert_called_once_with(10)
     assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [20]
+
+
+@pytest.mark.parametrize("iterator", [(i for i in range(3)), iter(range(3))])
+def test_spy_return_iter(mocker: MockerFixture, iterator: Iterator[int]) -> None:
+    class Foo:
+        def method(self) -> Iterator[int]:
+            return iterator
+
+    foo = Foo()
+    spy = mocker.spy(foo, "method")
+    result = list(foo.method())
+
+    assert result == [0, 1, 2]
+    assert spy.spy_return is not None
+    assert spy.spy_return_iter is not None
+    assert list(spy.spy_return_iter) == result
+    assert spy.spy_return_list == [ANY]
+
+
+@pytest.mark.parametrize("iterable", [(0, 1, 2), [0, 1, 2], range(3)])
+def test_spy_return_iter_ignore_plain_iterable(
+    mocker: MockerFixture, iterable: Iterable[int]
+) -> None:
+    class Foo:
+        def method(self) -> Iterable[int]:
+            return iterable
+
+    foo = Foo()
+    spy = mocker.spy(foo, "method")
+    result = foo.method()
+
+    assert result == iterable
+    assert spy.spy_return == result
+    assert spy.spy_return_iter is None
+    assert spy.spy_return_list == [result]
+
+
+def test_spy_return_iter_unset_in_last_call(mocker: MockerFixture) -> None:
+    class Foo:
+        iterables = [
+            (i for i in range(3)),
+            [3, 4, 5],
+        ]
+
+        def method(self) -> Iterable[int]:
+            return self.iterables.pop(0)
+
+    foo = Foo()
+    spy = mocker.spy(foo, "method")
+    result_iterator = list(foo.method())
+
+    assert result_iterator == [0, 1, 2]
+    assert list(spy.spy_return_iter) == result_iterator
+
+    result_iterable = foo.method()
+    assert result_iterable == [3, 4, 5]
+    assert spy.spy_return_iter is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -545,15 +545,15 @@ def test_callable_like_spy(testdir: Any, mocker: MockerFixture) -> None:
     assert spy.spy_return_list == [20]
 
 
-@pytest.mark.parametrize("iterator", [(i for i in range(3)), iter(range(3))])
+@pytest.mark.parametrize("iterator", [(i for i in range(3)), iter([0, 1, 2])])
 def test_spy_return_iter(mocker: MockerFixture, iterator: Iterator[int]) -> None:
     class Foo:
-        def method(self) -> Iterator[int]:
+        def bar(self) -> Iterator[int]:
             return iterator
 
     foo = Foo()
-    spy = mocker.spy(foo, "method")
-    result = list(foo.method())
+    spy = mocker.spy(foo, "bar")
+    result = list(foo.bar())
 
     assert result == [0, 1, 2]
     assert spy.spy_return is not None
@@ -567,12 +567,12 @@ def test_spy_return_iter_ignore_plain_iterable(
     mocker: MockerFixture, iterable: Iterable[int]
 ) -> None:
     class Foo:
-        def method(self) -> Iterable[int]:
+        def bar(self) -> Iterable[int]:
             return iterable
 
     foo = Foo()
-    spy = mocker.spy(foo, "method")
-    result = foo.method()
+    spy = mocker.spy(foo, "bar")
+    result = foo.bar()
 
     assert result == iterable
     assert spy.spy_return == result
@@ -587,17 +587,17 @@ def test_spy_return_iter_unset_in_last_call(mocker: MockerFixture) -> None:
             [3, 4, 5],
         ]
 
-        def method(self) -> Iterable[int]:
+        def bar(self) -> Iterable[int]:
             return self.iterables.pop(0)
 
     foo = Foo()
-    spy = mocker.spy(foo, "method")
-    result_iterator = list(foo.method())
+    spy = mocker.spy(foo, "bar")
+    result_iterator = list(foo.bar())
 
     assert result_iterator == [0, 1, 2]
     assert list(spy.spy_return_iter) == result_iterator
 
-    result_iterable = foo.method()
+    result_iterable = foo.bar()
     assert result_iterable == [3, 4, 5]
     assert spy.spy_return_iter is None
 

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -583,7 +583,7 @@ def test_spy_return_iter_ignore_plain_iterable(
 
 def test_spy_return_iter_resets(mocker: MockerFixture) -> None:
     class Foo:
-        iterables: list[Any] = [
+        iterables: Any = [
             (i for i in range(3)),
             99,
         ]

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -581,11 +581,11 @@ def test_spy_return_iter_ignore_plain_iterable(
     assert spy.spy_return_list == [result]
 
 
-def test_spy_return_iter_unset_in_last_call(mocker: MockerFixture) -> None:
+def test_spy_return_iter_resets(mocker: MockerFixture) -> None:
     class Foo:
         iterables = [
             (i for i in range(3)),
-            [3, 4, 5],
+            99,
         ]
 
         def bar(self) -> Iterable[int]:
@@ -598,8 +598,7 @@ def test_spy_return_iter_unset_in_last_call(mocker: MockerFixture) -> None:
     assert result_iterator == [0, 1, 2]
     assert list(spy.spy_return_iter) == result_iterator
 
-    result_iterable = foo.bar()
-    assert result_iterable == [3, 4, 5]
+    assert foo.bar() == 99
     assert spy.spy_return_iter is None
 
 


### PR DESCRIPTION
Recently I've run into situation where I wanted to `spy` on a method returning `Iterator`.
That wasn't possible because the iterator is already consumed by the time you try to assert it.

In this PR I add a new attribute, `spy_return_iter` storing a duplicate of the returned iterator (leveraging `itertools.tee`). 