### PR TITLE
Set `spy_return_iter` only when explicitly requested

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Releases
 ========
 
+UNRELEASED
+----------
+
+*UNRELEASED*
+
+* `#529 <https://github.com/pytest-dev/pytest-mock/issues/529>`_: Fixed ``itertools._tee object has no attribute error`` -- now ``duplicate_iterators=True`` must be passed to ``mocker.spy`` to duplicate iterators.
+
 3.15.0
 ------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -78,10 +78,10 @@ also tracks function/method calls, return values and exceptions raised.
 The object returned by ``mocker.spy`` is a ``MagicMock`` object, so all standard checking functions
 are available (like ``assert_called_once_with`` or ``call_count`` in the examples above).
 
-In addition, spy objects contain two extra attributes:
+In addition, spy objects contain four extra attributes:
 
 * ``spy_return``: contains the last returned value of the spied function.
-* ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator. Uses `tee <https://docs.python.org/3/library/itertools.html#itertools.tee>`__) to duplicate the iterator.
+* ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator and spy was created using ``.spy(..., duplicate_iterators)``. Uses `tee <https://docs.python.org/3/library/itertools.html#itertools.tee>`__) to duplicate the iterator.
 * ``spy_return_list``: contains a list of all returned values of the spied function (new in ``3.13``).
 * ``spy_exception``: contain the last exception value raised by the spied function/method when
   it was last called, or ``None`` if no exception was raised.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -81,7 +81,7 @@ are available (like ``assert_called_once_with`` or ``call_count`` in the example
 In addition, spy objects contain four extra attributes:
 
 * ``spy_return``: contains the last returned value of the spied function.
-* ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator and spy was created using ``.spy(..., duplicate_iterators)``. Uses `tee <https://docs.python.org/3/library/itertools.html#itertools.tee>`__) to duplicate the iterator.
+* ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator and spy was created using ``.spy(..., duplicate_iterators=True)``. Uses `tee <https://docs.python.org/3/library/itertools.html#itertools.tee>`__) to duplicate the iterator.
 * ``spy_return_list``: contains a list of all returned values of the spied function (new in ``3.13``).
 * ``spy_exception``: contain the last exception value raised by the spied function/method when
   it was last called, or ``None`` if no exception was raised.

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -157,13 +157,16 @@ class MockerFixture:
         """
         self._mock_cache.remove(mock)
 
-    def spy(self, obj: object, name: str) -> MockType:
+    def spy(
+        self, obj: object, name: str, duplicate_iterators: bool = False
+    ) -> MockType:
         """
         Create a spy of method. It will run method normally, but it is now
         possible to use `mock` call features with it, like call count.
 
         :param obj: An object.
         :param name: A method in object.
+        :param duplicate_iterators: Whether to keep a copy of the returned iterator in `spy_return_iter`.
         :return: Spy object.
         """
         method = getattr(obj, name)
@@ -177,7 +180,7 @@ class MockerFixture:
                 spy_obj.spy_exception = e
                 raise
             else:
-                if isinstance(r, Iterator):
+                if duplicate_iterators and isinstance(r, Iterator):
                     r, duplicated_iterator = itertools.tee(r, 2)
                     spy_obj.spy_return_iter = duplicated_iterator
                 else:


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-mock/issues/529