### PR TITLE
Add SpyType for mocker.spy results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+Unreleased
+----------
+
+* `#547 <https://github.com/pytest-dev/pytest-mock/issues/547>`_: Added ``SpyType`` for annotating ``mocker.spy`` results.
+
 3.15.1
 ------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -75,10 +75,8 @@ also tracks function/method calls, return values and exceptions raised.
         assert spy.call_count == 1
         assert spy.spy_return == 42
 
-The object returned by ``mocker.spy`` is a ``MagicMock`` object, so all standard checking functions
-are available (like ``assert_called_once_with`` or ``call_count`` in the examples above).
-
-In addition, spy objects contain four extra attributes:
+The object returned by ``mocker.spy`` is a ``pytest_mock.SpyType`` object which subclasses ``MagicMock``, so all standard checking functions
+are available (like ``assert_called_once_with`` or ``call_count`` in the examples above), in addition to four extra attributes:
 
 * ``spy_return``: contains the last returned value of the spied function.
 * ``spy_return_iter``: contains a duplicate of the last returned value of the spied function if the value was an iterator and spy was created using ``.spy(..., duplicate_iterators=True)``. Uses `tee <https://docs.python.org/3/library/itertools.html#itertools.tee>`__) to duplicate the iterator.

--- a/src/pytest_mock/__init__.py
+++ b/src/pytest_mock/__init__.py
@@ -2,6 +2,7 @@ from pytest_mock.plugin import AsyncMockType
 from pytest_mock.plugin import MockerFixture
 from pytest_mock.plugin import MockType
 from pytest_mock.plugin import PytestMockWarning
+from pytest_mock.plugin import SpyType
 from pytest_mock.plugin import class_mocker
 from pytest_mock.plugin import mocker
 from pytest_mock.plugin import module_mocker
@@ -18,6 +19,7 @@ __all__ = [
     "MockFixture",
     "MockType",
     "PytestMockWarning",
+    "SpyType",
     "pytest_addoption",
     "pytest_configure",
     "session_mocker",

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -34,6 +34,9 @@ MockType = Union[
 
 
 class SpyType(unittest.mock.Mock):
+    """
+    Type stub used to annotate the result of ``mocker.spy``.
+    """
     spy_return: Any
     spy_return_iter: Optional[Iterator[Any]]
     spy_return_list: list[Any]

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -33,6 +33,13 @@ MockType = Union[
 ]
 
 
+class SpyType(unittest.mock.Mock):
+    spy_return: Any
+    spy_return_iter: Optional[Iterator[Any]]
+    spy_return_list: list[Any]
+    spy_exception: Optional[BaseException]
+
+
 class PytestMockWarning(UserWarning):
     """Base class for all warnings emitted by pytest-mock."""
 
@@ -157,9 +164,7 @@ class MockerFixture:
         """
         self._mock_cache.remove(mock)
 
-    def spy(
-        self, obj: object, name: str, duplicate_iterators: bool = False
-    ) -> MockType:
+    def spy(self, obj: object, name: str, duplicate_iterators: bool = False) -> SpyType:
         """
         Create a spy of method. It will run method normally, but it is now
         possible to use `mock` call features with it, like call count.
@@ -210,7 +215,10 @@ class MockerFixture:
 
         autospec = inspect.ismethod(method) or inspect.isfunction(method)
 
-        spy_obj = self.patch.object(obj, name, side_effect=wrapped, autospec=autospec)
+        spy_obj = cast(
+            SpyType,
+            self.patch.object(obj, name, side_effect=wrapped, autospec=autospec),
+        )
         spy_obj.spy_return = None
         spy_obj.spy_return_iter = None
         spy_obj.spy_return_list = []

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -37,6 +37,7 @@ class SpyType(unittest.mock.Mock):
     """
     Type stub used to annotate the result of ``mocker.spy``.
     """
+
     spy_return: Any
     spy_return_iter: Optional[Iterator[Any]]
     spy_return_list: list[Any]

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -16,6 +16,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 from pytest_mock import PytestMockWarning
+from pytest_mock import SpyType
 
 pytest_plugins = "pytester"
 
@@ -283,6 +284,25 @@ def test_instance_method_spy(mocker: MockerFixture) -> None:
     assert spy.spy_return_list == [20, 22, 24]
 
 
+def test_spy_type(mocker: MockerFixture) -> None:
+    class Foo:
+        def bar(self) -> str:
+            return "ok"
+
+    foo = Foo()
+    spy: SpyType = mocker.spy(foo, "bar")
+
+    assert getattr(spy, "spy_return") is None
+    assert getattr(spy, "spy_return_iter") is None
+    assert spy.spy_return_list == []
+    assert getattr(spy, "spy_exception") is None
+    spy.assert_not_called()
+
+    assert foo.bar() == "ok"
+    assert spy.spy_return == "ok"
+    assert spy.spy_return_list == ["ok"]
+
+
 # Ref: https://docs.python.org/3/library/exceptions.html#exception-hierarchy
 @pytest.mark.parametrize(
     "exc_cls",
@@ -357,14 +377,14 @@ def test_spy_reset(mocker: MockerFixture) -> None:
             return x * 3
 
     spy = mocker.spy(Foo, "bar")
-    assert spy.spy_return is None
-    assert spy.spy_return_iter is None
+    assert getattr(spy, "spy_return") is None
+    assert getattr(spy, "spy_return_iter") is None
     assert spy.spy_return_list == []
-    assert spy.spy_exception is None
+    assert getattr(spy, "spy_exception") is None
 
     Foo().bar(10)
     assert spy.spy_return == 30
-    assert spy.spy_return_iter is None  # type:ignore[unreachable]
+    assert spy.spy_return_iter is None
     assert spy.spy_return_list == [30]
     assert spy.spy_exception is None
 
@@ -373,8 +393,8 @@ def test_spy_reset(mocker: MockerFixture) -> None:
 
     with pytest.raises(ValueError):
         Foo().bar(0)
-    assert spy.spy_return is None
-    assert spy.spy_return_iter is None
+    assert getattr(spy, "spy_return") is None
+    assert getattr(spy, "spy_return_iter") is None
     assert spy.spy_return_list == []
     assert str(spy.spy_exception) == "invalid x"
 
@@ -624,6 +644,7 @@ def test_spy_return_iter_resets(mocker: MockerFixture) -> None:
     result_iterator = list(foo.bar())
 
     assert result_iterator == [0, 1, 2]
+    assert spy.spy_return_iter is not None
     assert list(spy.spy_return_iter) == result_iterator
 
     assert foo.bar() == 99

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -284,6 +284,12 @@ def test_instance_method_spy(mocker: MockerFixture) -> None:
     assert spy.spy_return_list == [20, 22, 24]
 
 
+def assert_spy_has_no_return(spy: SpyType) -> None:
+    assert spy.spy_return is None
+    assert spy.spy_return_iter is None
+    assert spy.spy_return_list == []
+
+
 def test_spy_type(mocker: MockerFixture) -> None:
     class Foo:
         def bar(self) -> str:
@@ -292,10 +298,8 @@ def test_spy_type(mocker: MockerFixture) -> None:
     foo = Foo()
     spy: SpyType = mocker.spy(foo, "bar")
 
-    assert getattr(spy, "spy_return") is None
-    assert getattr(spy, "spy_return_iter") is None
-    assert spy.spy_return_list == []
-    assert getattr(spy, "spy_exception") is None
+    assert_spy_has_no_return(spy)
+    assert spy.spy_exception is None
     spy.assert_not_called()
 
     assert foo.bar() == "ok"
@@ -377,10 +381,8 @@ def test_spy_reset(mocker: MockerFixture) -> None:
             return x * 3
 
     spy = mocker.spy(Foo, "bar")
-    assert getattr(spy, "spy_return") is None
-    assert getattr(spy, "spy_return_iter") is None
-    assert spy.spy_return_list == []
-    assert getattr(spy, "spy_exception") is None
+    assert_spy_has_no_return(spy)
+    assert spy.spy_exception is None
 
     Foo().bar(10)
     assert spy.spy_return == 30
@@ -393,9 +395,7 @@ def test_spy_reset(mocker: MockerFixture) -> None:
 
     with pytest.raises(ValueError):
         Foo().bar(0)
-    assert getattr(spy, "spy_return") is None
-    assert getattr(spy, "spy_return_iter") is None
-    assert spy.spy_return_list == []
+    assert_spy_has_no_return(spy)
     assert str(spy.spy_exception) == "invalid x"
 
     Foo().bar(15)


### PR DESCRIPTION
﻿## Summary
- add a public `SpyType` for `mocker.spy()` return values
- expose the spy-only attributes (`spy_return`, `spy_return_iter`, `spy_return_list`, `spy_exception`) to type checkers
- export `SpyType` from `pytest_mock` and add a regression test

Closes #547.

## Validation
- `pre-commit run --files CHANGELOG.rst src/pytest_mock/__init__.py src/pytest_mock/plugin.py tests/test_pytest_mock.py`
- `python -m mypy src tests`
- `python -m pytest tests/test_pytest_mock.py::test_spy_type tests/test_pytest_mock.py::test_instance_method_spy tests/test_pytest_mock.py::test_spy_return_iter_resets -q`
- `python -m pytest tests -q -k "not introspection"`
- `python -m compileall -q src\pytest_mock`
- `git diff --check`

## Notes
The full local `python -m pytest tests -q` run has four existing assertion-introspection output failures on this Windows/Python 3.13 environment. They appear unrelated to this typing change, so this PR leaves those tests untouched.
