### PR TITLE
docs: replace outdated HTTP links with current HTTPS URLs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -72,4 +72,4 @@ Note that this feature is automatically disabled with the ``--tb=native`` option
 mechanism used to suppress traceback entries from ``mock`` module does not work with that option
 anyway plus it generates confusing messages on Python 3.5 due to exception chaining
 
-.. _advanced assertions: http://docs.pytest.org/en/stable/assert.html
+.. _advanced assertions: https://docs.pytest.org/en/stable/assert.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ pytest-mock
 ===========
 
 This `pytest`_ plugin provides a ``mocker`` fixture which is a thin-wrapper around the patching API
-provided by the `mock package <http://pypi.python.org/pypi/mock>`_:
+provided by the `mock package <https://pypi.org/project/mock>`_:
 
 .. code-block:: python
 
@@ -28,7 +28,7 @@ comparing calls.
 Install
 =======
 
-Install using `pip <http://pip-installer.org/>`_:
+Install using `pip <https://pip.pypa.io/>`_:
 
 .. code-block:: console
 


### PR DESCRIPTION
## What

Fix three outdated documentation links in the `docs/` directory:

| File | Old URL | New URL |
|------|---------|----------|
| `docs/index.rst` | `http://pip-installer.org/` | `https://pip.pypa.io/` |
| `docs/index.rst` | `http://pypi.python.org/pypi/mock` | `https://pypi.org/project/mock` |
| `docs/configuration.rst` | `http://docs.pytest.org/en/stable/assert.html` | `https://docs.pytest.org/en/stable/assert.html` |

## Why

- **`pip-installer.org`** is an old domain that no longer works (returns 403). The official pip documentation has been at `pip.pypa.io` for years.
- **`pypi.python.org/pypi/mock`** uses the legacy PyPI URL format. PyPI migrated to `pypi.org` in 2018 and the old URL pattern (`pypi.python.org/pypi/`) is deprecated.
- **`http://docs.pytest.org`** used plain HTTP; upgrading to HTTPS is a security best practice and the site redirects to HTTPS anyway.

## How verified

Searched the `docs/` directory for all `http://` links, confirmed these three are the only ones present, and verified the replacement URLs are correct and use modern canonical forms.