### PR TITLE
fix: drop obsolete unwrap RuntimeError guard

### DIFF
--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -698,17 +698,7 @@ def wrap_assert_methods(config: Any) -> None:
 
 def unwrap_assert_methods() -> None:
     for patcher in _mock_module_patches:
-        try:
-            patcher.stop()
-        except RuntimeError as e:
-            # a patcher might have been stopped by user code (#137)
-            # so we need to catch this error here and ignore it;
-            # unfortunately there's no public API to check if a patch
-            # has been started, so catching the error it is
-            if str(e) == "stop called on unstarted patcher":
-                pass
-            else:
-                raise
+        patcher.stop()
     _mock_module_patches[:] = []
     _mock_module_originals.clear()
 


### PR DESCRIPTION
## Summary

- Remove the obsolete `RuntimeError` guard around assertion-wrapper patch cleanup.
- Keep the existing cleanup flow intact while relying on current `unittest.mock`/`mock` behavior where stopping an already-stopped patcher is no longer expected to raise `stop called on unstarted patcher`.

Fixes #147

## Validation

- `tox run -e py311`
- `tox run -e pytest6,norewrite`
- `pre-commit run --all-files`
