### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,96 @@
+# Auto-detect text files and normalize line endings
+* text=auto
+
+# Images
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.tif binary
+*.tiff binary
+*.ico binary
+*.webp binary
+*.bmp binary
+*.psd binary
+# SVG is XML text, not binary
+*.svg text
+
+# Fonts
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.otf binary
+
+# Archives
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.rar binary
+*.tar binary
+*.tar.gz binary
+*.tgz binary
+*.zip binary
+*.zst binary
+
+# Compiled objects and libraries
+*.a binary
+*.lib binary
+*.o binary
+*.obj binary
+
+# Executables and shared libraries
+*.dll binary
+*.dylib binary
+*.exe binary
+*.so binary
+
+# Documents and data
+*.pdf binary
+*.db binary
+*.sqlite binary
+*.sqlite3 binary
+
+# Preserve byte sequences in patches
+*.patch -text
+*.diff -text
+
+# Audio
+*.aac binary
+*.aif binary
+*.aiff binary
+*.flac binary
+*.m4a binary
+*.mid binary
+*.midi binary
+*.mp3 binary
+*.ogg binary
+*.wav binary
+*.wma binary
+
+# Video
+*.3gp binary
+*.avi binary
+*.flv binary
+*.m4v binary
+*.mkv binary
+*.mov binary
+*.mp4 binary
+*.mpeg binary
+*.mpg binary
+*.ogv binary
+*.webm binary
+*.wmv binary
+
+# Lockfiles
+uv.lock binary
+Pipfile.lock binary
+poetry.lock binary
+
+# Python bytecode and data (Python.gitattributes, CPython)
+*.pyc binary
+*.pyo binary
+*.pyd binary
+*.whl binary
+*.pkl binary
+*.pickle binary


### PR DESCRIPTION
Add a `.gitattributes` file so that Git normalises line endings consistently
across the Windows and Linux environments in the CI matrix.

The file uses `* text=auto` for universal newline normalisation and marks
binary file types (images, fonts, archives, compiled objects, lockfiles,
Python bytecode) so they are never mangled by Git's line-ending conversion.

This is especially relevant for pytest-mock because `test.yml` runs the full
test suite on both `ubuntu-latest` and `windows-latest` across Python
3.10–3.14.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a
human before submission.
