### PR TITLE
Remove RuntimeError handling obsolete since mock 3.0.0 (#147)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Unreleased
 
 * `#547 <https://github.com/pytest-dev/pytest-mock/issues/547>`_: Added ``SpyType`` for annotating ``mocker.spy`` results.
 * Dropped support for EOL Python 3.9.
+* `#147 <https://github.com/pytest-dev/pytest-mock/issues/147>`_: Removed handling of ``RuntimeError: stop called on unstarted patcher``, which can no longer occur in the supported Python versions.
 
 3.15.1
 ------

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -696,17 +696,7 @@ def wrap_assert_methods(config: Any) -> None:
 
 def unwrap_assert_methods() -> None:
     for patcher in _mock_module_patches:
-        try:
-            patcher.stop()
-        except RuntimeError as e:
-            # a patcher might have been stopped by user code (#137)
-            # so we need to catch this error here and ignore it;
-            # unfortunately there's no public API to check if a patch
-            # has been started, so catching the error it is
-            if str(e) == "stop called on unstarted patcher":
-                pass
-            else:
-                raise
+        patcher.stop()
     _mock_module_patches[:] = []
     _mock_module_originals.clear()
 


### PR DESCRIPTION
Closes #147.

The `RuntimeError: stop called on unstarted patcher` handling in `unwrap_assert_methods` was added for #137, when calling `stop()` on an already-stopped patcher raised. That raise was removed from CPython in mock 3.0.0 (bpo-36366), so the branch is unreachable on any currently supported version.

Verification:
- `pytest-mock` requires Python >=3.10; the raise was removed in mock 3.0.0 / CPython 3.8.
- The string "stop called on unstarted patcher" does not appear anywhere in `unittest/mock.py` on 3.12.
- Calling `patcher.stop()` twice on 3.12 is a silent no-op rather than raising.

No behaviour change for users. Local test results are unchanged from `main` (the four failing introspection tests fail identically before and after this change, unrelated to it).