### PR TITLE
Support spying on properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Releases
 Unreleased
 ----------
 
+* `#35 <https://github.com/pytest-dev/pytest-mock/issues/35>`_: ``mocker.spy`` now works on properties, spying on the getter while still returning the real value.
 * `#547 <https://github.com/pytest-dev/pytest-mock/issues/547>`_: Added ``SpyType`` for annotating ``mocker.spy`` results.
 * Dropped support for EOL Python 3.9.
 * `#147 <https://github.com/pytest-dev/pytest-mock/issues/147>`_: Removed handling of ``RuntimeError: stop called on unstarted patcher``, which can no longer occur in the supported Python versions.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -86,6 +86,26 @@ are available (like ``assert_called_once_with`` or ``call_count`` in the example
 
 Besides functions and normal methods, ``mocker.spy`` also works for class and static methods.
 
+``mocker.spy`` also works on properties: pass the property name and the getter is spied on
+while the real value is still returned on access.
+
+.. code-block:: python
+
+    def test_spy_property(mocker):
+        class Foo:
+            @property
+            def bar(self):
+                return 42
+
+        foo = Foo()
+        spy = mocker.spy(foo, "bar")
+        assert foo.bar == 42
+        assert spy.call_count == 1
+        assert spy.spy_return == 42
+
+Note that a property is defined on the class, so spying on it affects every instance of the
+class until the spy is undone. The setter and deleter, if any, are left untouched.
+
 As of version 3.0.0, ``mocker.spy`` also works with ``async def`` functions.
 
 .. note::

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -171,11 +171,19 @@ class MockerFixture:
         Create a spy of method. It will run method normally, but it is now
         possible to use `mock` call features with it, like call count.
 
+        If ``name`` refers to a ``property``, the property's getter is spied on
+        instead. The real value is still returned on attribute access, and the
+        returned spy records each access.
+
         :param obj: An object.
-        :param name: A method in object.
+        :param name: A method or property in object.
         :param duplicate_iterators: Whether to keep a copy of the returned iterator in `spy_return_iter`.
         :return: Spy object.
         """
+        static_attr = inspect.getattr_static(obj, name, None)
+        if isinstance(static_attr, property):
+            return self._spy_on_property(obj, name, static_attr, duplicate_iterators)
+
         method = getattr(obj, name)
 
         def wrapper(*args, **kwargs):
@@ -221,6 +229,48 @@ class MockerFixture:
             SpyType,
             self.patch.object(obj, name, side_effect=wrapped, autospec=autospec),
         )
+        spy_obj.spy_return = None
+        spy_obj.spy_return_iter = None
+        spy_obj.spy_return_list = []
+        spy_obj.spy_exception = None
+        return spy_obj
+
+    def _spy_on_property(
+        self,
+        obj: object,
+        name: str,
+        prop: property,
+        duplicate_iterators: bool,
+    ) -> SpyType:
+        """Spy on a property getter. See :meth:`spy`."""
+        owner = obj if inspect.isclass(obj) else type(obj)
+        spy_obj = cast(SpyType, self.mock_module.PropertyMock())
+
+        def getter(instance: object) -> Any:
+            spy_obj.spy_return = None
+            spy_obj.spy_exception = None
+            spy_obj()
+            try:
+                r = prop.fget(instance)  # type: ignore[misc]
+            except BaseException as e:
+                spy_obj.spy_exception = e
+                raise
+            else:
+                if duplicate_iterators and isinstance(r, Iterator):
+                    r, duplicated_iterator = itertools.tee(r, 2)
+                    spy_obj.spy_return_iter = duplicated_iterator
+                else:
+                    spy_obj.spy_return_iter = None
+
+                spy_obj.spy_return = r
+                spy_obj.spy_return_list.append(r)
+            return r
+
+        # Replace the property on the class with one that keeps the original
+        # setter/deleter but funnels reads through the spy. patch.object also
+        # registers the patcher so it is undone at the end of the test.
+        self.patch.object(owner, name, property(getter, prop.fset, prop.fdel))
+
         spy_obj.spy_return = None
         spy_obj.spy_return_iter = None
         spy_obj.spy_return_list = []

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -441,6 +441,101 @@ def test_instance_method_by_subclass_spy(mocker: MockerFixture) -> None:
     assert spy.spy_return_list == [20, 20]
 
 
+def test_property_spy(mocker: MockerFixture) -> None:
+    class Foo:
+        def __init__(self, value: int) -> None:
+            self._value = value
+
+        @property
+        def value(self) -> int:
+            return self._value * 2
+
+    foo = Foo(10)
+    spy = mocker.spy(foo, "value")
+
+    # accessing the property returns the real, computed value
+    assert foo.value == 20
+    assert foo.value == 20
+    assert spy.call_count == 2
+    assert spy.spy_return == 20
+    assert spy.spy_return_iter is None
+    assert spy.spy_return_list == [20, 20]
+    assert spy.spy_exception is None
+
+
+def test_property_spy_by_class(mocker: MockerFixture) -> None:
+    class Foo:
+        def __init__(self, value: int) -> None:
+            self._value = value
+
+        @property
+        def value(self) -> int:
+            return self._value * 2
+
+    spy = mocker.spy(Foo, "value")
+
+    # the original getter still receives the correct instance
+    assert Foo(10).value == 20
+    assert Foo(21).value == 42
+    assert spy.call_count == 2
+    assert spy.spy_return == 42
+    assert spy.spy_return_list == [20, 42]
+
+
+def test_property_spy_exception(mocker: MockerFixture) -> None:
+    class Foo:
+        @property
+        def value(self) -> int:
+            raise ValueError("boom")
+
+    foo = Foo()
+    spy = mocker.spy(foo, "value")
+
+    with pytest.raises(ValueError, match="boom"):
+        _ = foo.value
+
+    spy.assert_called_once()
+    assert isinstance(spy.spy_exception, ValueError)
+    assert spy.spy_return is None
+
+
+def test_property_spy_keeps_setter(mocker: MockerFixture) -> None:
+    class Foo:
+        def __init__(self, value: int) -> None:
+            self._value = value
+
+        @property
+        def value(self) -> int:
+            return self._value
+
+        @value.setter
+        def value(self, new_value: int) -> None:
+            self._value = new_value
+
+    foo = Foo(1)
+    spy = mocker.spy(foo, "value")
+
+    # the setter is left untouched, so assignment keeps working
+    foo.value = 5
+    assert foo.value == 5
+    spy.assert_called_once()
+    assert spy.spy_return == 5
+
+
+def test_property_spy_undone(mocker: MockerFixture) -> None:
+    class Foo:
+        @property
+        def value(self) -> int:
+            return 42
+
+    original = Foo.__dict__["value"]
+    foo = Foo()
+    mocker.spy(foo, "value")
+    assert Foo.__dict__["value"] is not original
+    mocker.stopall()
+    assert Foo.__dict__["value"] is original
+
+
 @skip_pypy
 def test_class_method_spy(mocker: MockerFixture) -> None:
     class Foo:


### PR DESCRIPTION
This teaches `mocker.spy` to work on properties, which currently fails with `AttributeError: can't set attribute` because spy reads the value with `getattr` and then tries to patch the attribute on the instance.

The fix detects when the named attribute is a `property` and spies on its getter instead. Reads still return the real, computed value, and the returned spy records each access along with `spy_return`, `spy_return_list` and `spy_exception`, just like spying on a method. The original setter and deleter are left untouched. Because a property lives on the class, the spy applies to every instance until it is undone, which I noted in the docs.

Closes #35. There's a changelog entry and tests covering instance and by-class spying, exceptions, the setter staying intact, and the property being restored after `stopall`.