### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         os: [ubuntu-latest, windows-latest]
         tox_env: ["py"]
         include:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Unreleased
 * `#547 <https://github.com/pytest-dev/pytest-mock/issues/547>`_: Added ``SpyType`` for annotating ``mocker.spy`` results.
 * Dropped support for EOL Python 3.9.
 * `#147 <https://github.com/pytest-dev/pytest-mock/issues/147>`_: Removed handling of ``RuntimeError: stop called on unstarted patcher``, which can no longer occur in the supported Python versions.
+* Added support for Python 3.15.
 
 3.15.1
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development :: Testing",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.5.3
-envlist = py{310,311,312,313,314}, norewrite, pytest6
+envlist = py{310,311,312,313,314,315}, norewrite, pytest6
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.15.0 rc1 is out, which means that there will be no more ABI changes, and the API is pretty much stable. It is now safe to test against and to specify support for it :)

This PR adds Python 3.15 support to pytest-mock by enabling testing on it and adding a PyPI classifier.