### PR TITLE
Fix duplicate_iterators for async spies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Releases
 Unreleased
 ----------
 
+* Fixed ``duplicate_iterators=True`` for async functions spied with ``mocker.spy``.
 * `#547 <https://github.com/pytest-dev/pytest-mock/issues/547>`_: Added ``SpyType`` for annotating ``mocker.spy`` results.
 * Dropped support for EOL Python 3.9.
 * `#147 <https://github.com/pytest-dev/pytest-mock/issues/147>`_: Removed handling of ``RuntimeError: stop called on unstarted patcher``, which can no longer occur in the supported Python versions.

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -206,6 +206,12 @@ class MockerFixture:
                 spy_obj.spy_exception = e
                 raise
             else:
+                if duplicate_iterators and isinstance(r, Iterator):
+                    r, duplicated_iterator = itertools.tee(r, 2)
+                    spy_obj.spy_return_iter = duplicated_iterator
+                else:
+                    spy_obj.spy_return_iter = None
+
                 spy_obj.spy_return = r
                 spy_obj.spy_return_list.append(r)
             return r

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -666,6 +666,27 @@ async def test_instance_async_method_spy(mocker: MockerFixture) -> None:
     assert result == 20
 
 
+@pytest.mark.asyncio
+async def test_async_spy_return_iter_duplicates_iterator_when_enabled(
+    mocker: MockerFixture,
+) -> None:
+    class Foo:
+        async def bar(self) -> Iterator[int]:
+            return iter([0, 1, 2])
+
+    foo = Foo()
+    spy = mocker.spy(foo, "bar", duplicate_iterators=True)
+    result = await foo.bar()
+
+    assert list(result) == [0, 1, 2]
+    assert spy.spy_return is not None
+    assert spy.spy_return_iter is not None
+    assert list(spy.spy_return_iter) == [0, 1, 2]
+
+    [return_value] = spy.spy_return_list
+    assert isinstance(return_value, Iterator)
+
+
 @contextmanager
 def assert_traceback() -> Generator[None, None, None]:
     """


### PR DESCRIPTION
## Problem

mocker.spy supports async functions and documents spy_return_iter for iterator returns when duplicate_iterators=True. The synchronous spy wrapper honors that option, but the async wrapper returned the original iterator without creating the duplicate, leaving spy_return_iter as None.

## Fix

Apply the existing itertools.tee handling in the async spy wrapper when duplicate_iterators=True and the awaited result is an iterator.

The unreleased changelog now records the behavior correction.

## Tests

- ./.venv/bin/python -m pytest tests/test_pytest_mock.py::test_async_spy_return_iter_duplicates_iterator_when_enabled -q - failed before the fix as expected; passed after the fix
- ./.venv/bin/tox run -e py312 - passed; 92 tests
- ./.venv/bin/tox run -e norewrite - passed; 88 passed, 4 expected skips
- ./.venv/bin/pre-commit run --all-files - passed
- ./.venv/bin/python -m compileall -q src tests/test_pytest_mock.py - passed
- git diff HEAD^ HEAD --check - passed

## Compatibility

The change affects only the existing opt-in duplicate_iterators=True path for async functions. Non-iterable async results and duplicate_iterators=False retain their prior behavior.

## Related issue

Independent reproduction; no issue is claimed. Open issue #519 concerns a separate Python-version-specific unittest.mock autospec behavior and was not reproduced on the available Python 3.12 runtime.
