### PR TITLE
Honour resetall() arguments for non-callable mocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Releases
 Unreleased
 ----------
 
+* `#606 <https://github.com/pytest-dev/pytest-mock/pull/606>`_: ``mocker.resetall(return_value=True, side_effect=True)`` now also applies to non-callable mocks, such as those returned by ``mocker.create_autospec(SomeClass, instance=True)``. Previously both arguments were silently ignored for them.
 * `#547 <https://github.com/pytest-dev/pytest-mock/issues/547>`_: Added ``SpyType`` for annotating ``mocker.spy`` results.
 * Dropped support for EOL Python 3.9.
 * `#147 <https://github.com/pytest-dev/pytest-mock/issues/147>`_: Removed handling of ``RuntimeError: stop called on unstarted patcher``, which can no longer occur in the supported Python versions.

--- a/src/pytest_mock/plugin.py
+++ b/src/pytest_mock/plugin.py
@@ -130,12 +130,6 @@ class MockerFixture:
         :param bool return_value: Reset the return_value of mocks.
         :param bool side_effect: Reset the side_effect of mocks.
         """
-        supports_reset_mock_with_args: tuple[type[Any], ...]
-        if hasattr(self, "AsyncMock"):
-            supports_reset_mock_with_args = (self.Mock, self.AsyncMock)
-        else:
-            supports_reset_mock_with_args = (self.Mock,)
-
         for mock_item in self._mock_cache:
             # See issue #237.
             if not hasattr(mock_item.mock, "reset_mock"):
@@ -145,7 +139,11 @@ class MockerFixture:
                 mock_item.mock.spy_return_list = []
             if hasattr(mock_item.mock, "spy_return_iter"):
                 mock_item.mock.spy_return_iter = None
-            if isinstance(mock_item.mock, supports_reset_mock_with_args):
+            # ``reset_mock`` is defined on ``NonCallableMock``, which is the base
+            # of every mock class. Autospecced *functions* are plain functions
+            # carrying a no-argument ``reset_mock`` closure, so they take the
+            # ``else`` branch.
+            if isinstance(mock_item.mock, self.NonCallableMock):
                 mock_item.mock.reset_mock(
                     return_value=return_value, side_effect=side_effect
                 )

--- a/tests/test_pytest_mock.py
+++ b/tests/test_pytest_mock.py
@@ -224,6 +224,19 @@ def test_mocker_resetall(mocker: MockerFixture) -> None:
     assert mocked_object.run.return_value != "mocked"
 
 
+def test_mocker_resetall_non_callable_mock(mocker: MockerFixture) -> None:
+    """``resetall`` must honour its arguments for non-callable mocks too (#389)."""
+    mocked_object = mocker.create_autospec(TestObject, instance=True)
+    assert not isinstance(mocked_object, mocker.Mock)
+    mocked_object.run.return_value = "mocked"
+    mocked_object.run.side_effect = ValueError
+
+    mocker.resetall(return_value=True, side_effect=True)
+
+    assert mocked_object.run.return_value != "mocked"
+    assert mocked_object.run.side_effect is None
+
+
 class TestMockerStub:
     def test_call(self, mocker: MockerFixture) -> None:
         stub = mocker.stub()


### PR DESCRIPTION
`reset_mock()` is defined on `NonCallableMock`, but `resetall()` narrowed the kwargs-capable set to `(Mock, AsyncMock)`. `NonCallableMagicMock` — what `mocker.create_autospec(cls, instance=True)` returns — is not a `Mock` subclass, so it took the `else` branch and `return_value=` / `side_effect=` were silently dropped:

```python
m = mocker.create_autospec(TestObject, instance=True)
m.run.return_value = "mocked"
mocker.resetall(return_value=True, side_effect=True)
m.run.return_value   # still "mocked"
```

Calling `m.reset_mock(return_value=True, side_effect=True)` directly does reset it, and the callable variant `create_autospec(cls)` already works — so the two disagree today.

The guard itself is load-bearing and I kept it. Autospecced *functions* carry a no-argument `reset_mock` closure (#237), and those are plain functions, not `NonCallableMock` instances, so they still take the `else` branch. Removing the isinstance check altogether re-breaks `test_spy_reset` with the original `TypeError` — I checked. `AsyncMock` in the old tuple was redundant: it already subclasses `Mock`.

Why nothing caught it: #390 added `create_autospec` results to the cache in 2023, which is how non-callable mocks started reaching this loop; the type guard is from #241 (2021) and was not revisited. The test #390 added uses `create_autospec(TestObject)` without `instance=True` — the one variant that takes the working branch.

Ran on Python 3.12: `pytest tests/` gives 87 passed here vs 86 on `main`, same venv and command. Four tests fail identically on both (`test_detailed_introspection*`, `test_assert_called_*_with_introspection`) — assertion-output differences under pytest 9.1.1, not related to this change. ruff 0.16.5 check + format, mypy 2.3.1 and rst-lint are clean at the versions `.pre-commit-config.yaml` pins.

How I found it: enumerating the public `mocker.*` keyword arguments and checking where each is actually honoured. These two are honoured on one branch only.

AI assistance: this change and its test were drafted with Claude Opus 5 (`claude-opus-5`). The commands and numbers above were run locally.
